### PR TITLE
@W-21609208 - Added Github Actions to Update Catalog & Verify Zip

### DIFF
--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -1,0 +1,124 @@
+name: Update Catalog.json w New App Version PR
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**/*.zip'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-catalog-pr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed ZIPs, create tags, update catalog.json (in working tree)
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          # 1) Find ZIP files changed in this push to main (merge commit)
+          mapfile -t changed_zips < <(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- '**/*.zip')
+
+          if [[ ${#changed_zips[@]} -eq 0 ]]; then
+            echo "No .zip files changed. Exiting."
+            exit 0
+          fi
+
+          echo "Changed ZIPs:"
+          printf ' - %s\n' "${changed_zips[@]}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          updated_any=false
+
+          for zip_path in "${changed_zips[@]}"; do
+            # Only act on ZIPs that exist after the merge (skip deletions)
+            [[ -f "$zip_path" ]] || continue
+
+            zip_dir="$(dirname "$zip_path")"
+            catalog_path="$zip_dir/catalog.json"
+            manifest_path="$zip_dir/manifest.json"
+
+            # 2) If no catalog.json next to this zip, exit (no-op)
+            if [[ ! -f "$catalog_path" ]]; then
+              echo "No catalog.json at $catalog_path. Exiting."
+              exit 0
+            fi
+
+            if [[ ! -f "$manifest_path" ]]; then
+              echo "::error file=$manifest_path::manifest.json not found next to ZIP ($zip_path)"
+              exit 1
+            fi
+
+            # Version from manifest.json (expects .version)
+            version="$(jq -r '.version // empty' "$manifest_path")"
+            if [[ -z "$version" || "$version" == "null" ]]; then
+              echo "::error file=$manifest_path::Missing .version in manifest.json"
+              exit 1
+            fi
+
+            # 3) Tag name = zip filename without .zip
+            zip_file="$(basename "$zip_path")"
+            tag_name="${zip_file%.zip}"
+
+            # Create + push tag (skip if already exists)
+            if ! git rev-parse -q --verify "refs/tags/$tag_name" >/dev/null; then
+              git tag -a "$tag_name" -m "Release $tag_name"
+            fi
+            if ! git ls-remote --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1; then
+              git push origin "refs/tags/$tag_name"
+            fi
+
+            # 4) Update latest and 5) Append a new versions entry
+            tmp="$(mktemp)"
+            jq --arg v "$version" --arg t "$tag_name" '
+              .versions = (.versions // []) |
+              .latest = {"version": $v, "tag": $t} |
+              .versions = (.versions + [{"version": $v, "tag": $t}])
+            ' "$catalog_path" > "$tmp"
+
+            mv "$tmp" "$catalog_path"
+            git add "$catalog_path"
+            updated_any=true
+          done
+
+          if [[ "$updated_any" != "true" ]]; then
+            echo "No catalog updates to propose. Exiting."
+            exit 0
+          fi
+
+          if git diff --cached --quiet; then
+            echo "No effective catalog changes staged. Exiting."
+            exit 0
+          fi
+
+      - name: Create PR with catalog.json update
+        if: ${{ !cancelled() }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: CI/update-catalog-${{ github.run_id }}
+          delete-branch: true
+          commit-message: "CI: update catalog.json after ZIP merge"
+          title: "CI: update catalog.json after ZIP merge"
+          body: |
+            This PR was auto-generated after a ZIP file was merged into `main`.
+
+            - Creates a tag matching the ZIP filename (without `.zip`)
+            - Updates `catalog.json` `latest`
+            - Appends a new entry to `catalog.json` `versions`
+          labels: |
+            automation

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -1,0 +1,255 @@
+name: Verify CAP Checksum & Structure
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, edited, ready_for_review]
+    paths:
+      - '**/*.zip'
+
+jobs:
+  verify-zips:
+    runs-on: ubuntu-latest
+    env:
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    steps:
+      - name: Checkout PR HEAD
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Step 1 - Verify sha256 in manifest.json for changed ZIPs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # Collect changed ZIPs into a file that the next step can reuse
+          : > changed_zips.txt
+
+          while IFS= read -r -d '' f; do
+            [[ "$f" == *.zip ]] && printf '%s\n' "$f" >> changed_zips.txt
+          done < <(git diff --name-only -z "$BASE_SHA" "$HEAD_SHA")
+
+          if [[ ! -s changed_zips.txt ]]; then
+            echo "No .zip files changed in this PR. Nothing to verify."
+            exit 0
+          fi
+
+          echo "Changed ZIP files:"
+          sed 's/^/ - /' changed_zips.txt
+
+          while IFS= read -r zip_path; do
+            # If deleted in PR head, skip 
+            if [[ ! -f "$zip_path" ]]; then
+              echo "Skipping (not present in PR head): $zip_path"
+              continue
+            fi
+
+            dir="$(dirname "$zip_path")"
+            manifest_path="$dir/manifest.json"
+
+            if [[ ! -f "$manifest_path" ]]; then
+              echo "::error file=$manifest_path::manifest.json not found next to ZIP ($zip_path)"
+              exit 1
+            fi
+
+            # Compute checksum of the ZIP
+            computed="$(sha256sum "$zip_path" | awk '{print $1}' | tr '[:upper:]' '[:lower:]')"
+
+            # Read sha256 from manifest.json
+            manifest_sha="$(jq -r '.sha256 // empty' "$manifest_path" | tr '[:upper:]' '[:lower:]')"
+
+            if [[ -z "$manifest_sha" || "$manifest_sha" == "null" ]]; then
+              echo "::error file=$manifest_path::Missing or empty \"sha256\" field in manifest.json"
+              exit 1
+            fi
+
+            echo "ZIP:      $zip_path"
+            echo "Computed: $computed"
+            echo "Manifest: $manifest_sha"
+
+            if [[ "$computed" != "$manifest_sha" ]]; then
+              echo "::error file=$manifest_path::sha256 mismatch for $zip_path (computed=$computed, manifest=$manifest_sha)"
+              exit 1
+            fi
+          done < changed_zips.txt
+
+      - name: Step 2 - Verify manifest zip matches file + manifest version is unique
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          [[ -s changed_zips.txt ]] || exit 0
+
+          while IFS= read -r zip_path; do
+            [[ -f "$zip_path" ]] || continue
+
+            dir="$(dirname "$zip_path")"
+            manifest_path="$dir/manifest.json"
+            catalog_path="$dir/catalog.json"
+
+            if [[ ! -f "$catalog_path" ]]; then
+              echo "::error file=$catalog_path::catalog.json not found next to ZIP ($zip_path)"
+              exit 1
+            fi
+
+            if [[ ! -f "$manifest_path" ]]; then
+              echo "::error file=$manifest_path::manifest.json not found next to ZIP ($zip_path)"
+              exit 1
+            fi
+
+            zip_file="$(basename "$zip_path")"
+            manifest_zip="$(jq -r '.zip // empty' "$manifest_path")"
+            if [[ -z "$manifest_zip" || "$manifest_zip" == "null" ]]; then
+              echo "::error file=$manifest_path::Missing \"zip\" field in manifest.json"
+              exit 1
+            fi
+
+            version="$(jq -r '.version // empty' "$manifest_path")"
+            if [[ -z "$version" || "$version" == "null" ]]; then
+              echo "::error file=$manifest_path::Missing \"version\" field in manifest.json"
+              exit 1
+            fi
+
+            # Verify zip field in manifest matches file name
+            if [[ "$manifest_zip" != "$zip_file" ]]; then
+              echo "::error file=$manifest_path::manifest.json \"zip\" ($manifest_zip) does not match changed zip filename ($zip_file)"
+              exit 1
+            fi
+
+            # Verify new version in manifest is unique
+            if jq -e --arg v "$version" '.versions[]? | select(.version == $v)' "$catalog_path" >/dev/null; then
+              echo "::error file=$catalog_path::Version $version already exists in catalog.json"
+              exit 1
+            fi
+          done < changed_zips.txt
+
+      - name: Step 3 - Unzip and verify top level folder structure
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          # List of allowed top level folder names
+          allowed=("impex" "app-configuration" "storefront-next" "cartridges")
+
+          [[ -s changed_zips.txt ]] || exit 0
+
+          while IFS= read -r zip_path; do
+            [[ -f "$zip_path" ]] || continue
+
+            # Unzip file to temp dir
+            tmpdir="$(mktemp -d)"
+            unzip -q "$zip_path" -d "$tmpdir"
+
+            # Root should be exactly one directory (the wrapper folder)
+            mapfile -t roots < <(find "$tmpdir" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | grep -v '^__MACOSX$' | sort -u)
+            if [[ ${#roots[@]} -ne 1 ]]; then
+              echo "::error file=$zip_path::Expected exactly 1 root directory after unzip, found ${#roots[@]}: ${roots[*]}"
+              rm -rf "$tmpdir"
+              exit 1
+            fi
+            root="$tmpdir/${roots[0]}"
+
+            # Check immediate child directories of root are allowed
+            mapfile -t children < <(find "$root" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | grep -v '^__MACOSX$' | sort -u)
+            for c in "${children[@]}"; do
+              ok=false
+              for a in "${allowed[@]}"; do
+                [[ "$c" == "$a" ]] && ok=true && break
+              done
+              if [[ "$ok" == "false" ]]; then
+                echo "::error file=$zip_path::Disallowed directory under root: \"$c\". Allowed: ${allowed[*]}"
+                rm -rf "$tmpdir"
+                exit 1
+              fi
+            done
+            rm -rf "$tmpdir"
+          done < changed_zips.txt
+          
+      - name: Step 4 - [Tax] Verify hooks exist and scripts resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          required_hooks=(
+            "dw.apps.checkout.tax.calculate"
+            "dw.apps.checkout.tax.commit"
+            "dw.apps.checkout.tax.cancel"
+          )
+
+          [[ -s changed_zips.txt ]] || exit 0
+
+          is_tax_app=false
+
+          while IFS= read -r zip_path; do
+            [[ -f "$zip_path" ]] || continue
+
+            # Only run for ZIPs under tax/ at repo root
+            case "$zip_path" in
+              tax/*) is_tax_app=true ;;
+              *) continue ;;
+            esac
+
+            tmpdir="$(mktemp -d)"
+            trap 'rm -rf "$tmpdir"' RETURN
+
+            unzip -q "$zip_path" -d "$tmpdir"
+
+            # Find cartridges/site_cartridges anywhere under the unzip root
+            base="$(find "$tmpdir" -type d -path '*/cartridges/site_cartridges' -print -quit)"
+            if [[ -z "$base" || ! -d "$base" ]]; then
+              echo "::error file=$zip_path::Missing directory cartridges/site_cartridges in ZIP"
+              exit 1
+            fi
+
+            hooks_file="$(find "$base" -type f -name hooks.json -print -quit)"
+            if [[ -z "$hooks_file" ]]; then
+              echo "::error file=$zip_path::hooks.json not found under cartridges/site_cartridges"
+              exit 1
+            fi
+
+            hooks_dir="$(dirname "$hooks_file")"
+            echo "ZIP: $zip_path"
+            echo "hooks.json: $hooks_file"
+
+            # Ensure there are no non-required hook names
+            while IFS= read -r name; do
+              ok=false
+              for hook in "${required_hooks[@]}"; do
+                [[ "$name" == "$hook" ]] && ok=true && break
+              done
+              if [[ "$ok" == "false" ]]; then
+                echo "::error file=$hooks_file::Disallowed hook \"$name\". Only allowed: ${required_hooks[*]}"
+                exit 1
+              fi
+            done < <(jq -r '.hooks[]?.name // empty' "$hooks_file")
+
+            # Validate required hooks are present, and each has a script that exists
+            for hook in "${required_hooks[@]}"; do
+              script="$(jq -r --arg name "$hook" '.hooks[]? | select(.name == $name) | .script // empty' "$hooks_file" | head -n 1)"
+
+              if [[ -z "$script" || "$script" == "null" ]]; then
+                echo "::error file=$hooks_file::Missing hook or script for \"$hook\""
+                exit 1
+              fi
+
+              # script is relative to hooks.json location (strip leading ./)
+              rel="${script#./}"
+              target="$hooks_dir/$rel"
+
+              if [[ ! -f "$target" ]]; then
+                echo "::error file=$hooks_file::Script for \"$hook\" points to missing file: $script (resolved: $target)"
+                exit 1
+              fi
+            done
+
+            echo "SUCCESS - required tax hooks and scripts verified for $zip_path"
+
+            rm -rf "$tmpdir"
+            trap - RETURN
+          done < changed_zips.txt
+
+          if [[ "$is_tax_app" == "false" ]]; then
+            echo "No changed tax apps. Skipping Step 3."
+          fi


### PR DESCRIPTION
This PR adds Github Actions workflows that do the following:
1. On new PRs that include new CAP zips, verify the top level CAP structure and SHA256 provided in the manifest.json. It ensures that new commerce app version is unique in the catalog. Also, for tax apps, ensure all required hooks are present.
2. Once changes with new CAP zips are merged, action will create a PR to update the catalog and add a new entry with a freshly created tag, used to fetch older versions. 

**Note:** Following PRs will add actions to update the top level manifest used by BM, once that is added. 