### PR TITLE
Add Claude/Copilot plugin marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "commerce-apps",
+  "description": "Commerce Apps development skills for building, validating, and submitting Salesforce Commerce Cloud app packages.",
+  "version": "0.0.1",
+  "owner": {
+    "name": "Salesforce Agentforce Commerce",
+    "email": "clavery@salesforce.com"
+  },
+  "plugins": [
+    {
+      "name": "cap-dev",
+      "description": "Skills for scaffolding, packaging, validating, and submitting Commerce App Packages (CAPs) for Salesforce Commerce Cloud.",
+      "author": {
+        "name": "Salesforce"
+      },
+      "license": "Apache-2.0",
+      "source": "./.claude",
+      "category": "productivity",
+      "strict": false
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,8 +3,7 @@
   "description": "Commerce Apps development skills for building, validating, and submitting Salesforce Commerce Cloud app packages.",
   "version": "0.0.1",
   "owner": {
-    "name": "Salesforce Agentforce Commerce",
-    "email": "clavery@salesforce.com"
+    "name": "Salesforce"
   },
   "plugins": [
     {

--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,11 @@ $RECYCLE.BIN/
 # Keep the .gitignore file itself!
 !.gitignore
 
-# Keep Claude Code and Cursor directories
+# Keep Claude Code, Cursor, and plugin marketplace directories
 !.claude/
 !.claude/**
+!.claude-plugin/
+!.claude-plugin/**
 !.cursor/
 !.cursor/**
 

--- a/README.md
+++ b/README.md
@@ -208,55 +208,18 @@ copilot plugin marketplace add SalesforceCommerceCloud/commerce-apps
 copilot plugin install cap-dev@commerce-apps
 ```
 
-#### Cursor
+#### Manual Installation
 
-Copy skills into your project or user directory:
+For IDEs without marketplace support, copy the skills directory:
 
-```bash
-cp -r .claude/skills/ .cursor/skills/
-```
+| IDE | Project Path | User Path |
+|-----|--------------|-----------|
+| Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
+| Windsurf | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| Codex | `.codex/skills/` | `~/.config/codex/skills/` |
+| OpenCode | `.opencode/skills/` | `~/.config/opencode/skills/` |
 
-Or for global installation:
-
-```bash
-cp -r .claude/skills/ ~/.cursor/skills/
-```
-
-#### Windsurf
-
-```bash
-cp -r .claude/skills/ .windsurf/skills/
-```
-
-Or for global installation:
-
-```bash
-cp -r .claude/skills/ ~/.codeium/windsurf/skills/
-```
-
-#### Codex
-
-```bash
-cp -r .claude/skills/ .codex/skills/
-```
-
-Or for global installation:
-
-```bash
-cp -r .claude/skills/ ~/.config/codex/skills/
-```
-
-#### OpenCode
-
-```bash
-cp -r .claude/skills/ .opencode/skills/
-```
-
-Or for global installation:
-
-```bash
-cp -r .claude/skills/ ~/.config/opencode/skills/
-```
+Copy the skills from this repository's `.claude/skills/` directory into the appropriate path for your IDE.
 
 ### Available Skills
 

--- a/README.md
+++ b/README.md
@@ -180,26 +180,82 @@ Skills follow the open [Agent Skills](https://agentskills.io/home) standard and 
 
 ### Quick Start
 
-Install via your IDE's plugin marketplace:
+Install via your IDE's plugin marketplace or manually copy skills into your IDE's skills directory.
+
+#### Claude Code
 
 ```bash
-# Claude Code
 claude plugin marketplace add SalesforceCommerceCloud/commerce-apps
 claude plugin install cap-dev --scope project
 ```
 
-```text
-# Copilot (VS Code)
-In VS Code, open the Command Palette (Cmd/Ctrl+Shift+P) and run:
-  Chat: Install Plugin from Source
-Then enter:
-  SalesforceCommerceCloud/commerce-apps
+Use `--scope user` instead to install globally across all projects.
+
+#### GitHub Copilot (VS Code)
+
+In VS Code, open the Command Palette (`Cmd/Ctrl+Shift+P`) and run:
+
+```
+Chat: Install Plugin from Source
 ```
 
+Then enter: `SalesforceCommerceCloud/commerce-apps`
+
+#### GitHub Copilot CLI
+
 ```bash
-# Copilot CLI
 copilot plugin marketplace add SalesforceCommerceCloud/commerce-apps
 copilot plugin install cap-dev@commerce-apps
+```
+
+#### Cursor
+
+Copy skills into your project or user directory:
+
+```bash
+cp -r .claude/skills/ .cursor/skills/
+```
+
+Or for global installation:
+
+```bash
+cp -r .claude/skills/ ~/.cursor/skills/
+```
+
+#### Windsurf
+
+```bash
+cp -r .claude/skills/ .windsurf/skills/
+```
+
+Or for global installation:
+
+```bash
+cp -r .claude/skills/ ~/.codeium/windsurf/skills/
+```
+
+#### Codex
+
+```bash
+cp -r .claude/skills/ .codex/skills/
+```
+
+Or for global installation:
+
+```bash
+cp -r .claude/skills/ ~/.config/codex/skills/
+```
+
+#### OpenCode
+
+```bash
+cp -r .claude/skills/ .opencode/skills/
+```
+
+Or for global installation:
+
+```bash
+cp -r .claude/skills/ ~/.config/opencode/skills/
 ```
 
 ### Available Skills
@@ -235,19 +291,6 @@ Or ask your agent naturally:
 "Generate service impex for a REST API integration"
 ```
 
-### Manual Installation
-
-For IDEs without marketplace support, copy the skills directory:
-
-| IDE | Project Path | User Path |
-|-----|--------------|-----------|
-| Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
-| Windsurf | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
-| VS Code / Copilot | `.github/skills/` | `~/.copilot/skills/` |
-| Codex | `.codex/skills/` | `~/.config/codex/skills/` |
-| OpenCode | `.opencode/skills/` | `~/.config/opencode/skills/` |
-
-Copy the skills from this repository's `.claude/skills/` directory into the appropriate path for your IDE.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -30,35 +30,9 @@ Merchants install Commerce Apps through Business Manager with a click-to-install
 
 ## Quick Start
 
-### Using Claude Code Skills
+### Using Agent Skills
 
-If you're using Claude Code, we provide comprehensive skills to streamline development:
-
-**Start a new app:**
-```
-/scaffold-app
-```
-
-**Generate impex files:**
-```
-/generate-service-impex
-/generate-site-preferences-impex
-/generate-custom-object-impex
-```
-
-**Package and validate:**
-```
-/package-app
-/validate-app
-/validate-impex
-```
-
-**Submit to registry:**
-```
-/submit-app
-```
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for complete skill documentation.
+If you're using Claude Code, Cursor, Copilot, or another IDE with plugin support, install the `cap-dev` plugin for skills that streamline the full development workflow — see [Agent Skills](#agent-skills) below.
 
 ### Manual Development
 
@@ -198,13 +172,90 @@ Commerce App frontend extensions target the Storefront Next stack:
 
 Backend adapters use the Commerce Cloud Script API (CommonJS, `require('dw/...')` modules).
 
+## Agent Skills
+
+Turn your coding agent into a Commerce Apps specialist. Skills give Claude Code, Cursor, GitHub Copilot, and Codex deep expertise in scaffolding, packaging, validating, and submitting Commerce App Packages.
+
+Skills follow the open [Agent Skills](https://agentskills.io/home) standard and work with [Claude Code](https://claude.ai/code), Cursor, GitHub Copilot, VS Code, Codex, and others.
+
+### Quick Start
+
+Install via your IDE's plugin marketplace:
+
+```bash
+# Claude Code
+claude plugin marketplace add SalesforceCommerceCloud/commerce-apps
+claude plugin install cap-dev --scope project
+```
+
+```text
+# Copilot (VS Code)
+In VS Code, open the Command Palette (Cmd/Ctrl+Shift+P) and run:
+  Chat: Install Plugin from Source
+Then enter:
+  SalesforceCommerceCloud/commerce-apps
+```
+
+```bash
+# Copilot CLI
+copilot plugin marketplace add SalesforceCommerceCloud/commerce-apps
+copilot plugin install cap-dev@commerce-apps
+```
+
+### Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| `scaffold-app` | Generate complete app structure (UI-only, Backend-only, or Fullstack) |
+| `package-app` | Package app into registry-ready ZIP (handles new apps and version bumps) |
+| `generate-service-impex` | Generate service credentials, profiles, and definitions |
+| `generate-site-preferences-impex` | Generate custom site preference configurations |
+| `generate-custom-object-impex` | Generate custom object type definitions |
+| `validate-impex` | Validate impex XML syntax, structure, and common errors |
+| `validate-app` | Comprehensive pre-submission validation (structure, manifest, SHA256, impex) |
+| `submit-app` | Guided PR submission with automated GitHub CLI integration |
+
+### Usage
+
+Once installed, skills are available as slash commands in your IDE:
+
+```
+/scaffold-app        → Start a new Commerce App
+/package-app         → Package for submission
+/validate-app        → Run full validation suite
+/submit-app          → Submit PR to registry
+```
+
+Or ask your agent naturally:
+
+```
+"Create a new tax app called my-tax"
+"Package the my-tax app for submission"
+"Validate my app before I submit"
+"Generate service impex for a REST API integration"
+```
+
+### Manual Installation
+
+For IDEs without marketplace support, copy the skills directory:
+
+| IDE | Project Path | User Path |
+|-----|--------------|-----------|
+| Cursor | `.cursor/skills/` | `~/.cursor/skills/` |
+| Windsurf | `.windsurf/skills/` | `~/.codeium/windsurf/skills/` |
+| VS Code / Copilot | `.github/skills/` | `~/.copilot/skills/` |
+| Codex | `.codex/skills/` | `~/.config/codex/skills/` |
+| OpenCode | `.opencode/skills/` | `~/.config/opencode/skills/` |
+
+Copy the skills from this repository's `.claude/skills/` directory into the appropriate path for your IDE.
+
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for complete submission requirements and Claude Code skills documentation.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for complete submission requirements.
 
 ### Publishing Workflow
 
-**Using Claude Code (Recommended):**
+**Using Agent Skills (Recommended):**
 
 1. **Scaffold new app:** `/scaffold-app`
 2. **Build your app code** (cartridges, extensions, etc.)
@@ -250,26 +301,6 @@ Only commit these files to the repository:
 - IDE files (`.vscode/`, `.idea/`)
 
 The repository `.gitignore` is configured to exclude extracted directories and system files.
-
-### Claude Code Skills
-
-This repository includes comprehensive skills for Commerce App development:
-
-**App Development:**
-- `/scaffold-app` - Generate complete app structure (UI-only, Backend-only, or Fullstack)
-- `/package-app` - Package app into registry-ready ZIP (handles both new apps and version bumps)
-
-**Impex Generation:**
-- `/generate-service-impex` - Service credentials, profiles, definitions
-- `/generate-site-preferences-impex` - Custom site preferences
-- `/generate-custom-object-impex` - Custom object types
-- `/validate-impex` - Validate all impex files
-
-**Validation:**
-- `/validate-app` - Comprehensive architecture-aware validation (structure, manifest, impex, icons, translations)
-
-**Submission:**
-- `/submit-app` - Guide through PR submission process with automated GitHub CLI integration
 
 ### External Contributors
 


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/marketplace.json` exposing skills as the `cap-dev` plugin for Claude Code and Copilot marketplace installation
- Adds "Agent Skills" section to README with installation instructions, skill reference table, and manual IDE paths
- Consolidates the two prior "Claude Code Skills" sections into the single Agent Skills section
- Updates `.gitignore` to track `.claude-plugin/` directory
## Future PR

- b2c-cli install support (vibes, manual)
- codex marketplace
