### PR TITLE
Codex Marketplace; CLI Install; Refine skills docs

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "commerce-apps",
+  "interface": {
+    "displayName": "Commerce App Development"
+  },
+  "plugins": [
+    {
+      "name": "cap-dev",
+      "source": {
+        "source": "local",
+        "path": "./.claude"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "commerce-apps",
   "description": "Commerce Apps development skills for building, validating, and submitting Salesforce Commerce Cloud app packages.",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "owner": {
     "name": "Salesforce"
   },

--- a/.claude/.codex-plugin/plugin.json
+++ b/.claude/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cap-dev",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "Skills for scaffolding, packaging, validating, and submitting Commerce App Packages (CAPs) for Salesforce Commerce Cloud.",
   "author": {
     "name": "Salesforce"

--- a/.claude/.codex-plugin/plugin.json
+++ b/.claude/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "cap-dev",
+  "version": "0.0.1",
+  "description": "Skills for scaffolding, packaging, validating, and submitting Commerce App Packages (CAPs) for Salesforce Commerce Cloud.",
+  "author": {
+    "name": "Salesforce"
+  },
+  "homepage": "https://github.com/SalesforceCommerceCloud/commerce-apps",
+  "repository": "https://github.com/SalesforceCommerceCloud/commerce-apps",
+  "license": "Apache-2.0",
+  "keywords": [
+    "salesforce",
+    "commerce-cloud",
+    "commerce-apps",
+    "cap",
+    "storefront-next"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Commerce App Development",
+    "shortDescription": "Build, validate, and submit Commerce App Packages for Salesforce Commerce Cloud.",
+    "longDescription": "Skills for the full Commerce App Package (CAP) development lifecycle — scaffold new apps, generate impex configurations, package into registry-ready ZIPs, validate structure and manifests, and submit pull requests.",
+    "developerName": "Salesforce",
+    "category": "Productivity",
+    "capabilities": [
+      "Read"
+    ],
+    "brandColor": "#0D9DDA",
+    "websiteURL": "https://github.com/SalesforceCommerceCloud/commerce-apps",
+    "defaultPrompt": [
+      "Scaffold a new tax app",
+      "Generate service impex for a REST API integration",
+      "Package my app for submission",
+      "Validate my app before submitting"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -61,11 +61,13 @@ $RECYCLE.BIN/
 # Keep the .gitignore file itself!
 !.gitignore
 
-# Keep Claude Code, Cursor, and plugin marketplace directories
+# Keep Claude Code, Cursor, Codex, and plugin marketplace directories
 !.claude/
 !.claude/**
 !.claude-plugin/
 !.claude-plugin/**
+!.agents/
+!.agents/**
 !.cursor/
 !.cursor/**
 

--- a/README.md
+++ b/README.md
@@ -232,9 +232,6 @@ npx @salesforce/b2c-cli setup skills cap-dev --ide cursor
 
 # Install globally (user scope)
 npx @salesforce/b2c-cli setup skills cap-dev --ide cursor --global
-
-# Install specific skills only
-npx @salesforce/b2c-cli setup skills cap-dev --skill validate-app --skill package-app --ide cursor
 ```
 
 #### Manual Installation

--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ copilot plugin marketplace add SalesforceCommerceCloud/commerce-apps
 copilot plugin install cap-dev@commerce-apps
 ```
 
+#### Codex
+
+```bash
+codex plugin marketplace add SalesforceCommerceCloud/commerce-apps
+```
+
+Then in Codex, run `/plugins`, select the "Commerce Apps" marketplace, and install the `cap-dev` plugin.
+
 #### Manual Installation
 
 For IDEs without marketplace support, copy the skills directory:

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ Then in Codex, run `/plugins`, select the "Commerce Apps" marketplace, and insta
 The [B2C CLI](https://salesforcecommercecloud.github.io/b2c-developer-tooling/) can install skills to any supported IDE:
 
 ```bash
-# Interactive — choose IDE and skills
-npx @salesforce/b2c-cli setup skills cap-dev
+# Interactive — choose skillset, IDE, and skills
+npx @salesforce/b2c-cli setup skills
 
 # Non-interactive — install to a specific IDE
 npx @salesforce/b2c-cli setup skills cap-dev --ide cursor

--- a/README.md
+++ b/README.md
@@ -219,6 +219,24 @@ codex plugin marketplace add SalesforceCommerceCloud/commerce-apps
 
 Then in Codex, run `/plugins`, select the "Commerce Apps" marketplace, and install the `cap-dev` plugin.
 
+#### B2C CLI
+
+The [B2C CLI](https://salesforcecommercecloud.github.io/b2c-developer-tooling/) can install skills to any supported IDE:
+
+```bash
+# Interactive — choose IDE and skills
+npx @salesforce/b2c-cli setup skills cap-dev
+
+# Non-interactive — install to a specific IDE
+npx @salesforce/b2c-cli setup skills cap-dev --ide cursor
+
+# Install globally (user scope)
+npx @salesforce/b2c-cli setup skills cap-dev --ide cursor --global
+
+# Install specific skills only
+npx @salesforce/b2c-cli setup skills cap-dev --skill validate-app --skill package-app --ide cursor
+```
+
 #### Manual Installation
 
 For IDEs without marketplace support, copy the skills directory:

--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ Turn your coding agent into a Commerce Apps specialist. Skills give Claude Code,
 
 Skills follow the open [Agent Skills](https://agentskills.io/home) standard and work with [Claude Code](https://claude.ai/code), Cursor, GitHub Copilot, VS Code, Codex, and others.
 
+> [!TIP]
+> For B2C Commerce development and operations skills, also install the **B2C Developer Tooling** plugins. See the [B2C DX documentation](https://salesforcecommercecloud.github.io/b2c-developer-tooling/) for installation instructions.
+
 ### Quick Start
 
 Install via your IDE's plugin marketplace or manually copy skills into your IDE's skills directory.


### PR DESCRIPTION
## Summary
- Adds Codex marketplace install section to Agent Skills documentation in README
- Adds `.agents/plugins/marketplace.json` for Codex marketplace with friendly display name
- Adds `.claude/.codex-plugin/plugin.json` for Codex plugin metadata (interface, default prompts)
- Adds tip note directing users to B2C Developer Tooling plugins
- Adds non-marketplace install option with the b2c-cli
- Updates `.gitignore` to track `.agents/` directory

## Test plan
- [x] Verify `codex plugin marketplace add SalesforceCommerceCloud/commerce-apps` works
- [x] Verify Codex `/plugins` TUI shows "Commerce App Development" as the display name
- [x] Verify `cap-dev` plugin installs and skills are invocable
- [x] Verify Claude Code and Copilot install paths still work