### PR TITLE
@W-22388914 | Add storefront version support

### DIFF
--- a/.claude/skills/package-app/SKILL.md
+++ b/.claude/skills/package-app/SKILL.md
@@ -24,6 +24,10 @@ Build a registry-ready Commerce App Package (CAP) ZIP from an app directory.
 | Description | Short description | Yes |
 | Publisher name | `Avalara` | Yes |
 | Publisher URL | `https://developer.avalara.com/` | Yes |
+| SFNext min version | `1.0.0` | No |
+| SFNext max version | `2.0.0` | No |
+| SFRA min version | `7.0.0` | No |
+| SFRA max version | `8.0.0` | No |
 
 **Valid domains:** `tax`, `payment`, `shipping`, `gift-cards`, `ratings-and-reviews`, `loyalty`, `search`, `address-verification`, `analytics`, `approaching-discounts`, `fraud`
 
@@ -63,9 +67,14 @@ Ensure version matches throughout:
     "url": "<publisherUrl>",
     "support": "<publisherUrl>"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "storefrontSupport": {
+    "sfnext": { "minVersion": "<sfnextMinVersion>", "maxVersion": "<sfnextMaxVersion>" }
+  }
 }
 ```
+
+> **Note:** `storefrontSupport` is optional. Include only if the app declares a minimum storefront version. Omit the entire object if no version gating is needed. `maxVersion` is optional within each storefront key — include it only to guard against a known-incompatible future version (e.g., a major release that removes target IDs the app depends on); omit it for "no upper bound." When present, the values here must match the root manifest entry exactly.
 
 ## Step 4: Run validation
 
@@ -123,9 +132,14 @@ Update `commerce-apps-manifest/manifest.json`:
   "provider": "thirdParty",
   "version": "<version>",
   "zip": "<appName>-v<version>.zip",
-  "sha256": "<computed_hash>"
+  "sha256": "<computed_hash>",
+  "storefrontSupport": {
+    "sfnext": { "minVersion": "<sfnextMinVersion>", "maxVersion": "<sfnextMaxVersion>" }
+  }
 }
 ```
+
+> **Note:** Include `storefrontSupport` only if the app declares a minimum storefront version. Omit the entire field if no version gating is needed. `maxVersion` is optional within each storefront key — include it only to guard against a known-incompatible future version; omit it for "no upper bound." Values must match the corresponding fields in `commerce-app.json` exactly.
 
 **Icon:** Must match filename in ZIP's `icons/` directory. CI extracts automatically.
 

--- a/.claude/skills/scaffold-app/SKILL.md
+++ b/.claude/skills/scaffold-app/SKILL.md
@@ -52,6 +52,12 @@ If the user's description clearly indicates type, proceed directly. Otherwise as
 - Version (typically 1.0.0)
 - Description (one sentence)
 - Publisher name and URL
+- Minimum SFNext version (optional - semver `X.Y.Z` or `X.Y.Z-prerelease`, if the app requires a minimum Storefront Next version)
+- Maximum SFNext version (optional - semver, inclusive; only set if you've confirmed an incompatibility — e.g., a known-breaking future major release)
+- Minimum SFRA version (optional - semver `X.Y.Z` or `X.Y.Z-prerelease`, if the app requires a minimum SFRA version)
+- Maximum SFRA version (optional - semver, inclusive; same guidance as above)
+
+> When provided, add `storefrontSupport` to both `commerce-app.json` (inside the ZIP) and the root manifest entry. Values must match. Each storefront key (`sfnext`, `sfra`) accepts `minVersion` (required when the key is present) and an optional `maxVersion`.
 - Additional context (optional - docs, requirements, API details)
 
 **Folder Structure:** Apps must be at `{domain}/{appName}/` where `{appName}` matches the "id" field. Installation URL: `https://raw.githubusercontent.com/{owner}/{repo}/{tag}/{domain}/{appName}/{zipFileName}`

--- a/.claude/skills/validate-app/SKILL.md
+++ b/.claude/skills/validate-app/SKILL.md
@@ -54,6 +54,14 @@ Check `commerce-apps-manifest/manifest.json` has all required fields:
 - `zip` - matches actual filename
 - `sha256` - matches computed hash
 
+Optional fields (validate if present):
+- `storefrontSupport.sfnext.minVersion` - valid semver (`X.Y.Z` or `X.Y.Z-prerelease`)
+- `storefrontSupport.sfnext.maxVersion` - valid semver, optional (`X.Y.Z` or `X.Y.Z-prerelease`)
+- `storefrontSupport.sfra.minVersion` - valid semver (`X.Y.Z` or `X.Y.Z-prerelease`)
+- `storefrontSupport.sfra.maxVersion` - valid semver, optional (`X.Y.Z` or `X.Y.Z-prerelease`)
+- Only `sfnext` and `sfra` keys allowed inside `storefrontSupport`; only `minVersion` and `maxVersion` allowed inside each
+- `storefrontSupport` must be present in **both** the root manifest and `commerce-app.json` with matching values
+
 ## Step 5: Validate ZIP contents
 
 ```bash
@@ -91,6 +99,13 @@ Required fields:
 - `publisher.name`, `publisher.url`, `publisher.support`
 
 Version must match root manifest version.
+
+Optional fields (validate if present):
+- `storefrontSupport.sfnext.minVersion` - valid semver (`X.Y.Z` or `X.Y.Z-prerelease`)
+- `storefrontSupport.sfnext.maxVersion` - valid semver, optional (`X.Y.Z` or `X.Y.Z-prerelease`)
+- `storefrontSupport.sfra.minVersion` - valid semver (`X.Y.Z` or `X.Y.Z-prerelease`)
+- `storefrontSupport.sfra.maxVersion` - valid semver, optional (`X.Y.Z` or `X.Y.Z-prerelease`)
+- Values must match the corresponding fields in the root manifest entry
 
 ## Step 8: Validate storefront files (UI-only/Fullstack)
 

--- a/.github/scripts/root-manifest-utils.sh
+++ b/.github/scripts/root-manifest-utils.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 
+# Validates that a string is semver (major.minor.patch with optional pre-release suffix; no build metadata).
+validate_semver() {
+  local value="${1:?semver string is required}"
+  local field_name="${2:-version}"
+  local file="${3:-}"
+
+  if [[ ! "$value" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)*)?$ ]]; then
+    echo "::error file=$file::\"$field_name\" is not valid semver (expected X.Y.Z or X.Y.Z-prerelease): $value"
+    return 1
+  fi
+}
+
 # Validates manifest readability, JSON shape, and duplicate zip entries.
 validate_manifest() {
   local manifest_path="${1:?manifest path is required}"

--- a/.github/scripts/run-all-tests.sh
+++ b/.github/scripts/run-all-tests.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUITES=0
+FAILED=0
+
+for test_file in "$SCRIPT_DIR"/test-*.sh; do
+  [[ -f "$test_file" ]] || continue
+  echo "=== Running: $(basename "$test_file") ==="
+  SUITES=$((SUITES + 1))
+  if bash "$test_file"; then
+    echo "  -> Suite PASSED"
+  else
+    echo "  -> Suite FAILED"
+    FAILED=$((FAILED + 1))
+  fi
+  echo ""
+done
+
+echo "=== All Suites: $SUITES run, $FAILED failed ==="
+[[ "$FAILED" -eq 0 ]]

--- a/.github/scripts/test-root-manifest-utils.sh
+++ b/.github/scripts/test-root-manifest-utils.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/root-manifest-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=""
+cleanup() { [[ -n "$TMPDIR_ROOT" ]] && rm -rf "$TMPDIR_ROOT"; }
+trap cleanup EXIT
+TMPDIR_ROOT="$(mktemp -d)"
+
+assert_pass() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected pass)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fail() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  FAIL: $desc (expected fail)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+assert_json_eq() {
+  local desc="$1" expected="$2"; shift 2
+  local actual
+  actual="$("$@" 2>/dev/null)" || { echo "  FAIL: $desc (command failed)"; FAIL=$((FAIL + 1)); return; }
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+_MC=0
+mkmanifest() {
+  _MC=$((_MC + 1))
+  local f="$TMPDIR_ROOT/manifest_${_MC}.json"
+  printf '%s\n' "$1" > "$f"
+  printf '%s' "$f"
+}
+
+echo "=== root-manifest-utils.sh tests ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# validate_semver
+# ---------------------------------------------------------------------------
+echo "--- validate_semver ---"
+
+assert_pass  "1.0.0"                       validate_semver "1.0.0"
+assert_pass  "0.0.0"                       validate_semver "0.0.0"
+assert_pass  "100.200.300"                 validate_semver "100.200.300"
+assert_pass  "pre-release: 1.0.0-alpha"    validate_semver "1.0.0-alpha"
+assert_pass  "pre-release: 1.0.0-rc.1"     validate_semver "1.0.0-rc.1"
+assert_pass  "pre-release: 0.4.0-alpha.0"  validate_semver "0.4.0-alpha.0"
+assert_pass  "leading zeros: 01.02.03"     validate_semver "01.02.03"
+
+assert_fail  "two segments: 1.0"           validate_semver "1.0"
+assert_fail  "four segments: 1.2.3.4"      validate_semver "1.2.3.4"
+assert_fail  "single number: 1"            validate_semver "1"
+assert_fail  "letters in version: 1.a.0"   validate_semver "1.a.0"
+assert_fail  "build metadata: 1.0.0+build" validate_semver "1.0.0+build"
+assert_fail  "v-prefix: v1.0.0"            validate_semver "v1.0.0"
+assert_fail  "trailing space: '1.0.0 '"    validate_semver "1.0.0 "
+assert_fail  "empty pre-release: 1.0.0-"   validate_semver "1.0.0-"
+assert_fail  "just text: abc"              validate_semver "abc"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# validate_manifest
+# ---------------------------------------------------------------------------
+echo "--- validate_manifest ---"
+
+assert_fail  "file does not exist"  validate_manifest "$TMPDIR_ROOT/nonexistent.json"
+
+empty="$TMPDIR_ROOT/empty.json"; : > "$empty"
+assert_fail  "empty file"  validate_manifest "$empty"
+
+bad="$TMPDIR_ROOT/bad.json"; printf '{bad}' > "$bad"
+assert_fail  "invalid JSON"  validate_manifest "$bad"
+
+assert_pass  "minimal valid manifest"         validate_manifest "$(mkmanifest '{"tax":[]}')"
+assert_pass  "entries without zip field"      validate_manifest "$(mkmanifest '{"tax":[{"id":"a"},{"id":"b"}]}')"
+assert_pass  "unique zips"                    validate_manifest "$(mkmanifest '{"tax":[{"zip":"a.zip"},{"zip":"b.zip"}]}')"
+assert_pass  "non-array values are ignored"   validate_manifest "$(mkmanifest '{"defaultLocale":"en","tax":[{"zip":"a.zip"}]}')"
+assert_pass  "mixed entries with/without zip" validate_manifest "$(mkmanifest '{"tax":[{"id":"a"},{"zip":"b.zip"}]}')"
+
+assert_fail  "duplicate zips in same array"   validate_manifest "$(mkmanifest '{"tax":[{"zip":"dup.zip"},{"zip":"dup.zip"}]}')"
+assert_fail  "duplicate zips across arrays"   validate_manifest "$(mkmanifest '{"tax":[{"zip":"dup.zip"}],"shipping":[{"zip":"dup.zip"}]}')"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# get_manifest_entry_for_zip
+# ---------------------------------------------------------------------------
+echo "--- get_manifest_entry_for_zip ---"
+
+m1="$(mkmanifest '{"tax":[{"id":"app1","zip":"app1-v1.0.0.zip","version":"1.0.0"}]}')"
+assert_pass     "finds existing zip"   get_manifest_entry_for_zip "app1-v1.0.0.zip" "$m1"
+assert_json_eq  "returns correct JSON" '{"id":"app1","zip":"app1-v1.0.0.zip","version":"1.0.0"}' \
+  get_manifest_entry_for_zip "app1-v1.0.0.zip" "$m1"
+
+assert_fail  "zip not found"  get_manifest_entry_for_zip "no-such.zip" "$m1"
+
+m_dup="$(mkmanifest '{"tax":[{"zip":"dup.zip","id":"a"}],"shipping":[{"zip":"dup.zip","id":"b"}]}')"
+assert_fail  "rejects multiple matches"  get_manifest_entry_for_zip "dup.zip" "$m_dup"
+
+m2="$(mkmanifest '{"tax":[{"zip":"a.zip","id":"a"}],"shipping":[{"zip":"b.zip","id":"b"}]}')"
+assert_pass     "finds zip in second array"   get_manifest_entry_for_zip "b.zip" "$m2"
+assert_json_eq  "returns entry from second array" '{"zip":"b.zip","id":"b"}' \
+  get_manifest_entry_for_zip "b.zip" "$m2"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.github/scripts/test-security-scan.sh
+++ b/.github/scripts/test-security-scan.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCAN="$SCRIPT_DIR/security-scan.sh"
+
+PASS=0
+FAIL=0
+BUGS=0
+TMPDIR_ROOT=""
+cleanup() { [[ -n "$TMPDIR_ROOT" ]] && rm -rf "$TMPDIR_ROOT"; }
+trap cleanup EXIT
+TMPDIR_ROOT="$(mktemp -d)"
+
+_DC=0
+mkcap() {
+  _DC=$((_DC + 1))
+  local d="$TMPDIR_ROOT/cap_${_DC}"
+  mkdir -p "$d"
+  printf '%s' "$d"
+}
+
+run_scan() {
+  local rc=0
+  LAST_OUTPUT="$(bash "$SCAN" "$@" 2>&1)" || rc=$?
+  LAST_RC=$rc
+}
+
+assert_blocks() {
+  local desc="$1"; shift
+  run_scan "$@"
+  if [[ "$LAST_RC" -eq 1 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 1, got $LAST_RC)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_passes() {
+  local desc="$1"; shift
+  run_scan "$@"
+  if [[ "$LAST_RC" -eq 0 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 0, got $LAST_RC)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_clean() {
+  local desc="$1"; shift
+  run_scan "$@"
+  if [[ "$LAST_RC" -eq 0 ]] && echo "$LAST_OUTPUT" | grep -q "no findings"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 0 + no findings, got exit $LAST_RC)"
+    [[ -n "$LAST_OUTPUT" ]] && echo "    output: $(echo "$LAST_OUTPUT" | tail -3)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_warns() {
+  local desc="$1" needle="$2"; shift 2
+  run_scan "$@"
+  if [[ "$LAST_RC" -eq 0 ]] && echo "$LAST_OUTPUT" | grep -qF "$needle"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 0 + warning containing '$needle', got exit $LAST_RC)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_no_warning() {
+  local desc="$1" needle="$2"; shift 2
+  run_scan "$@"
+  if [[ "$LAST_RC" -eq 0 ]] && ! echo "$LAST_OUTPUT" | grep -qF "$needle"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected no '$needle' warning, but found it)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+# Document known bugs — assert current (broken) behavior so tests pass today
+# and will fail when the bug is fixed, prompting removal of the workaround.
+assert_known_bug() {
+  local bug_id="$1" desc="$2" expected_when_fixed="$3"; shift 3
+  run_scan "$@"
+  local actual_blocks=false
+  [[ "$LAST_RC" -eq 1 ]] && actual_blocks=true
+
+  if [[ "$expected_when_fixed" == "block" && "$actual_blocks" == "false" ]]; then
+    echo "  BUG:  $desc [$bug_id — should block but doesn't]"
+    BUGS=$((BUGS + 1))
+  elif [[ "$expected_when_fixed" == "pass" && "$actual_blocks" == "true" ]]; then
+    echo "  BUG:  $desc [$bug_id — should pass but blocks]"
+    BUGS=$((BUGS + 1))
+  else
+    echo "  FIXED? $desc [$bug_id — behavior changed, review this test]"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== security-scan.sh tests ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Infrastructure
+# ---------------------------------------------------------------------------
+echo "--- Infrastructure ---"
+
+run_scan
+if [[ "$LAST_RC" -eq 1 ]]; then echo "  PASS: no arguments exits 1"; PASS=$((PASS + 1))
+else echo "  FAIL: no arguments exits 1 (got $LAST_RC)"; FAIL=$((FAIL + 1)); fi
+
+run_scan "$TMPDIR_ROOT/nonexistent"
+if [[ "$LAST_RC" -eq 1 ]]; then echo "  PASS: nonexistent dir exits 1"; PASS=$((PASS + 1))
+else echo "  FAIL: nonexistent dir exits 1 (got $LAST_RC)"; FAIL=$((FAIL + 1)); fi
+
+cap="$(mkcap)"
+assert_clean "empty directory passes clean" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S1: eval / new Function
+# ---------------------------------------------------------------------------
+echo "--- S1: eval / new Function ---"
+
+cap="$(mkcap)"; printf 'var x = eval(input);\n' > "$cap/app.js"
+assert_blocks "eval() in code" "$cap"
+
+cap="$(mkcap)"; printf 'var fn = new Function("return x");\n' > "$cap/app.js"
+assert_blocks "new Function() in code" "$cap"
+
+# BUG: grep -n prefixes "1://" so grep -v '^\s*//' never matches the comment.
+cap="$(mkcap)"; printf '// eval(input);\n' > "$cap/app.js"
+assert_known_bug "S1-COMMENT" "eval in line comment should be ignored" "pass" "$cap"
+
+cap="$(mkcap)"; printf '// new Function("return x");\n' > "$cap/app.js"
+assert_known_bug "S1-COMMENT" "new Function in comment should be ignored" "pass" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S2: Dynamic require
+# ---------------------------------------------------------------------------
+echo "--- S2: Dynamic require ---"
+
+cap="$(mkcap)"; printf "var m = require(path + '/lib');\n" > "$cap/app.js"
+assert_blocks "dynamic require with concatenation" "$cap"
+
+cap="$(mkcap)"; printf "var m = require('lodash');\n" > "$cap/app.js"
+assert_passes "static require is safe" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S3: innerHTML
+# ---------------------------------------------------------------------------
+echo "--- S3: innerHTML ---"
+
+cap="$(mkcap)"; printf 'el.innerHTML = userInput;\n' > "$cap/app.js"
+assert_blocks "innerHTML assignment" "$cap"
+
+cap="$(mkcap)"; printf 'var x = el.innerHTML;\n' > "$cap/app.js"
+assert_passes "innerHTML read is safe" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S4: Hardcoded secrets
+# ---------------------------------------------------------------------------
+echo "--- S4: Hardcoded secrets ---"
+
+cap="$(mkcap)"; printf 'var key = "AKIAIOSFODNN7EXAMPLE";\n' > "$cap/app.js"
+assert_blocks "AWS access key" "$cap"
+
+cap="$(mkcap)"; printf 'var tok = "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789";\n' > "$cap/app.js"
+assert_blocks "GitHub PAT" "$cap"
+
+cap="$(mkcap)"; printf 'var t = "Bearer eyJhbGciOiJIUzI1NiJ9.xxxxx";\n' > "$cap/app.js"
+assert_blocks "Bearer token" "$cap"
+
+cap="$(mkcap)"; printf 'var s = "xoxb-1234567890-abcdef";\n' > "$cap/app.js"
+assert_blocks "Slack token" "$cap"
+
+cap="$(mkcap)"; printf 'var x = "sk_live_abc123defgh";\n' > "$cap/app.js"
+assert_blocks "Stripe-style live key" "$cap"
+
+# BUG: grep parses "-----BEGIN" as --BEGIN flag; pattern never matches.
+cap="$(mkcap)"; printf 'var k = "-----BEGIN RSA PRIVATE KEY-----";\n' > "$cap/app.js"
+assert_known_bug "S4-PRIVKEY" "RSA private key header should block" "block" "$cap"
+
+cap="$(mkcap)"; printf 'var k = "-----BEGIN PRIVATE KEY-----";\n' > "$cap/app.js"
+assert_known_bug "S4-PRIVKEY" "generic private key header should block" "block" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S5: Hardcoded secrets in XML
+# ---------------------------------------------------------------------------
+echo "--- S5: XML credentials ---"
+
+cap="$(mkcap)"; printf '<cred><password>SuperSecretPasswordThatIsLong</password></cred>\n' > "$cap/svc.xml"
+assert_blocks "long password in XML" "$cap"
+
+cap="$(mkcap)"; printf '<cred><password>short</password></cred>\n' > "$cap/svc.xml"
+assert_passes "short password in XML is safe (under 20 chars)" "$cap"
+
+cap="$(mkcap)"; printf '<cred><password>PLACEHOLDER_CHANGEME_VALUE</password></cred>\n' > "$cap/svc.xml"
+assert_passes "CHANGEME placeholder in XML is safe" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S6: Math.random
+# ---------------------------------------------------------------------------
+echo "--- S6: Math.random ---"
+
+cap="$(mkcap)"; printf 'var r = Math.random();\n' > "$cap/app.js"
+assert_warns "Math.random() warns" "Math.random()" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S7: Inline Authorization header
+# ---------------------------------------------------------------------------
+echo "--- S7: Inline Authorization ---"
+
+cap="$(mkcap)"; printf "req.setRequestHeader('Authorization', token);\n" > "$cap/app.js"
+assert_warns "setRequestHeader Authorization warns" "Inline Authorization" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# P1: console.log
+# ---------------------------------------------------------------------------
+echo "--- P1: console.log ---"
+
+cap="$(mkcap)"; printf 'console.log("debug");\n' > "$cap/cart.js"
+assert_warns "console.log warns" "console.log" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# P2: HTTPClient without timeout
+# ---------------------------------------------------------------------------
+echo "--- P2: HTTPClient timeout ---"
+
+cap="$(mkcap)"; printf 'var c = new HTTPClient();\nc.open("GET", url);\n' > "$cap/svc.js"
+assert_warns "HTTPClient without timeout warns" "HTTPClient used without explicit timeout" "$cap"
+
+# BUG: grep -qE 'setTimeout\|...' uses \| which is literal in ERE mode, not alternation.
+# setTimeout is never recognized, so HTTPClient with setTimeout still warns falsely.
+cap="$(mkcap)"; printf 'var c = new HTTPClient();\nc.setTimeout(5000);\n' > "$cap/svc.js"
+run_scan "$cap"
+if [[ "$LAST_RC" -eq 0 ]] && echo "$LAST_OUTPUT" | grep -qF "HTTPClient used without explicit timeout"; then
+  echo "  BUG:  HTTPClient with setTimeout still warns [P2-TIMEOUT — \\| is literal in ERE]"
+  BUGS=$((BUGS + 1))
+else
+  echo "  FIXED? HTTPClient with setTimeout no longer warns [P2-TIMEOUT — review this test]"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# P3: Service profile timeout
+# ---------------------------------------------------------------------------
+echo "--- P3: Service profile timeout ---"
+
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '<service-profile service-id="MySvc"/>\n' > "$cap/impex/install/profiles.xml"
+assert_warns "service profile without timeout-millis warns" "Service profile missing" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis></service-profile>\n' > "$cap/impex/install/profiles.xml"
+assert_no_warning "service profile with timeout — no timeout warning" "Service profile missing" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/impex/uninstall"
+printf '<service-profile service-id="MySvc"/>\n' > "$cap/impex/uninstall/profiles.xml"
+assert_no_warning "service profile in uninstall dir is skipped" "Service profile missing" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Q1: Hook script existence
+# ---------------------------------------------------------------------------
+echo "--- Q1: Hook script existence ---"
+
+cap="$(mkcap)"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+assert_blocks "missing hook script blocks" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { run(); } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_passes "existing hook script with export + try/catch passes" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Q2: Hook function exported
+# ---------------------------------------------------------------------------
+echo "--- Q2: Hook function export ---"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'function calculate() { try { run(); } catch(e) {} }\n' > "$cap/hooks/tax.js"
+assert_warns "unexported hook function warns" "expects export 'calculate'" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { run(); } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_no_warning "exported hook function — no export warning" "expects export" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Q3: Error handling in hooks
+# ---------------------------------------------------------------------------
+echo "--- Q3: Hook error handling ---"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { return 1; };\n' > "$cap/hooks/tax.js"
+assert_warns "hook without try/catch warns" "no try/catch" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { run(); } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_no_warning "hook with try/catch — no error handling warning" "no try/catch" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Q4: Install/uninstall service symmetry
+# ---------------------------------------------------------------------------
+echo "--- Q4: Service install/uninstall symmetry ---"
+
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '<services><service-credential service-id="svc1"/></services>\n' > "$cap/impex/install/services.xml"
+assert_blocks "install without uninstall blocks" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/impex/install" "$cap/impex/uninstall"
+printf '<services><service-credential service-id="svc1"/></services>\n' > "$cap/impex/install/services.xml"
+printf '<services><service-credential service-id="svc1"/></services>\n' > "$cap/impex/uninstall/services.xml"
+assert_blocks "uninstall without mode=delete blocks" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/impex/install" "$cap/impex/uninstall"
+printf '<services><service-credential service-id="svc1"/></services>\n' > "$cap/impex/install/services.xml"
+printf '<services mode="delete"><service-credential service-id="svc1" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+assert_passes "matching install/uninstall with mode=delete passes" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Q5: SITEID placeholder
+# ---------------------------------------------------------------------------
+echo "--- Q5: SITEID placeholder ---"
+
+cap="$(mkcap)"; printf '<site site-id="MySite"><prefs/></site>\n' > "$cap/prefs.xml"
+assert_warns "hardcoded site-id warns" "Hardcoded site-id" "$cap"
+
+cap="$(mkcap)"; printf '<site site-id="SITEID"><prefs/></site>\n' > "$cap/prefs.xml"
+assert_no_warning "SITEID placeholder — no site-id warning" "Hardcoded site-id" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Q6: Absolute paths
+# ---------------------------------------------------------------------------
+echo "--- Q6: Absolute paths ---"
+
+cap="$(mkcap)"; printf "var p = '/tmp/data';\n" > "$cap/app.js"
+assert_warns "absolute /tmp/ path warns" "Absolute path" "$cap"
+
+cap="$(mkcap)"; printf "var p = './data';\n" > "$cap/app.js"
+assert_no_warning "relative path — no absolute path warning" "Absolute path" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Combination: warnings don't block
+# ---------------------------------------------------------------------------
+echo "--- Combination ---"
+
+cap="$(mkcap)"
+printf 'console.log("debug");\nvar r = Math.random();\n' > "$cap/app.js"
+run_scan "$cap"
+if [[ "$LAST_RC" -eq 0 ]]; then echo "  PASS: multiple warnings still exit 0"; PASS=$((PASS + 1))
+else echo "  FAIL: multiple warnings still exit 0 (got $LAST_RC)"; FAIL=$((FAIL + 1)); fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed, $BUGS known bugs ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -1,0 +1,42 @@
+name: Test CI Scripts
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+    paths:
+      - '.github/scripts/**'
+
+jobs:
+  test-scripts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Require test file for new scripts
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for script in $(git diff --name-only --diff-filter=A "$BASE_SHA"..."$HEAD_SHA" -- '.github/scripts/*.sh'); do
+            base="$(basename "$script")"
+            case "$base" in
+              test-*|run-all-tests.sh) continue ;;
+            esac
+            name="${base%.sh}"
+            if [[ ! -f ".github/scripts/test-${name}.sh" ]]; then
+              missing+=("$script -> .github/scripts/test-${name}.sh")
+            fi
+          done
+          if [[ ${#missing[@]} -gt 0 ]]; then
+            echo "::error::New scripts added without a matching test file:"
+            printf '  %s\n' "${missing[@]}"
+            exit 1
+          fi
+
+      - name: Run script tests
+        run: ./.github/scripts/run-all-tests.sh

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -460,3 +460,88 @@ jobs:
             trap - RETURN
           done < changed_zips.txt
 
+      - name: Step 8 - Validate storefrontSupport fields in manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          source ".github/scripts/root-manifest-utils.sh"
+          manifest_path="commerce-apps-manifest/manifest.json"
+
+          [[ -s changed_zips.txt ]] || exit 0
+
+          while IFS= read -r zip_path; do
+            [[ -f "$zip_path" ]] || continue
+
+            zip_file="$(basename "$zip_path")"
+            entry="$(get_manifest_entry_for_zip "$zip_file" "$manifest_path")"
+
+            tmpdir="$(mktemp -d)"
+            unzip -q "$zip_path" -d "$tmpdir"
+            commerce_app="$(find "$tmpdir" -name 'commerce-app.json' -print -quit)"
+
+            manifest_has="$(jq -r 'has("storefrontSupport")' <<< "$entry")"
+            cap_has="false"
+            if [[ -n "$commerce_app" && -f "$commerce_app" ]]; then
+              cap_has="$(jq -r 'has("storefrontSupport")' "$commerce_app")"
+            fi
+
+            # Both absent: no gating declared, nothing to validate.
+            if [[ "$manifest_has" != "true" && "$cap_has" != "true" ]]; then
+              echo "No storefrontSupport for $zip_file - OK (optional)"
+              rm -rf "$tmpdir"
+              continue
+            fi
+
+            # Asymmetric presence is a mismatch in either direction.
+            if [[ "$manifest_has" != "$cap_has" ]]; then
+              echo "::error file=$manifest_path::storefrontSupport presence mismatch for $zip_file: manifest=$manifest_has, commerce-app.json=$cap_has"
+              rm -rf "$tmpdir"
+              exit 1
+            fi
+
+            # Reject unknown keys inside storefrontSupport (only sfnext and sfra allowed)
+            unknown_keys="$(jq -r '.storefrontSupport | keys[] | select(. != "sfnext" and . != "sfra")' <<< "$entry" 2>/dev/null || true)"
+            if [[ -n "$unknown_keys" ]]; then
+              echo "::error file=$manifest_path::Unknown keys in storefrontSupport for $zip_file: $unknown_keys"
+              rm -rf "$tmpdir"
+              exit 1
+            fi
+
+            # Reject unknown sub-keys inside sfnext / sfra (only minVersion and maxVersion allowed)
+            # and validate semver for any present min/max values.
+            for storefront in sfnext sfra; do
+              if [[ "$(jq -r --arg s "$storefront" '.storefrontSupport | has($s)' <<< "$entry")" == "true" ]]; then
+                bad_subkeys="$(jq -r --arg s "$storefront" '.storefrontSupport[$s] | keys[] | select(. != "minVersion" and . != "maxVersion")' <<< "$entry" 2>/dev/null || true)"
+                if [[ -n "$bad_subkeys" ]]; then
+                  echo "::error file=$manifest_path::Unknown keys in storefrontSupport.$storefront for $zip_file: $bad_subkeys"
+                  rm -rf "$tmpdir"
+                  exit 1
+                fi
+              fi
+              for field in minVersion maxVersion; do
+                val="$(jq -r --arg s "$storefront" --arg f "$field" '.storefrontSupport[$s][$f] // empty' <<< "$entry")"
+                if [[ -n "$val" ]]; then
+                  validate_semver "$val" "storefrontSupport.$storefront.$field" "$manifest_path"
+                  echo "  ✓ $storefront.$field=$val (valid semver)"
+                fi
+              done
+            done
+
+            # Cross-validate every storefrontSupport min/max value between manifest and commerce-app.json.
+            for storefront in sfnext sfra; do
+              for field in minVersion maxVersion; do
+                cap_val="$(jq -r --arg s "$storefront" --arg f "$field" '.storefrontSupport[$s][$f] // empty' "$commerce_app")"
+                manifest_val="$(jq -r --arg s "$storefront" --arg f "$field" '.storefrontSupport[$s][$f] // empty' <<< "$entry")"
+
+                if [[ "$cap_val" != "$manifest_val" ]]; then
+                  echo "::error file=$manifest_path::storefrontSupport.$storefront.$field mismatch for $zip_file: manifest='$manifest_val', commerce-app.json='$cap_val'"
+                  rm -rf "$tmpdir"
+                  exit 1
+                fi
+              done
+            done
+
+            rm -rf "$tmpdir"
+            echo "SUCCESS - storefrontSupport validated for $zip_file"
+          done < changed_zips.txt
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,16 @@ Your response:
 - Recommended size: 512x512px for raster, scalable for SVG
 - CI automatically extracts icons to `commerce-apps-manifest/icons/` on merge
 
+### 8. Storefront Support (Optional)
+- `storefrontSupport` must be present in **both** the root manifest entry and `commerce-app.json` inside the ZIP
+- Use semver format (`X.Y.Z` or `X.Y.Z-prerelease`) for all `minVersion` and `maxVersion` fields
+- Apps may declare `sfnext`, `sfra`, or both
+- `minVersion` is required when the storefront key is present; `maxVersion` is optional and inclusive
+- Use `maxVersion` only to guard against a known-incompatible future version (e.g., a major release that removes target IDs the app depends on); absence means "no upper bound"
+- If absent, no version gating is applied at install time
+- Values must match exactly between root manifest and `commerce-app.json`
+- Only `sfnext` and `sfra` keys are allowed inside `storefrontSupport`; only `minVersion` and `maxVersion` are allowed inside each storefront object
+
 **Icon validation examples:**
 ```
 Scenario 1: Avalara v0.2.8 with avalara.png (hash: abc123)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,6 +142,20 @@ Find your app’s entry in the appropriate domain array (e.g., `tax`, `shipping`
 
 > **Note:** For new versions of an existing app, you must at minimum update the `version`, `zip`, and `sha256` fields.
 
+#### Optional Fields
+
+- `storefrontSupport` - (Object) Declares storefront version compatibility. If absent, no version gating is applied at install time.
+  - `sfnext` - (Object) Storefront Next compatibility
+    - `minVersion` - (String) Minimum SFNext version the app requires (semver format: `X.Y.Z` or `X.Y.Z-prerelease`)
+    - `maxVersion` - (String, optional) Maximum SFNext version the app supports, inclusive (semver format: `X.Y.Z` or `X.Y.Z-prerelease`). Use this to guard against a known-incompatible future version (e.g., a major release that removes target IDs the app depends on).
+  - `sfra` - (Object) SFRA compatibility
+    - `minVersion` - (String) Minimum SFRA version the app requires (semver format: `X.Y.Z` or `X.Y.Z-prerelease`)
+    - `maxVersion` - (String, optional) Maximum SFRA version the app supports, inclusive (semver format: `X.Y.Z` or `X.Y.Z-prerelease`).
+
+An app may declare support for one or both storefront types. If the `storefrontSupport` field is absent or a specific storefront key is omitted, no version gating is applied for that storefront. Omit `maxVersion` unless you have confirmed an incompatibility — the installer treats absence as "no upper bound."
+
+When present, the `storefrontSupport` field in the root manifest must match the `storefrontSupport` field in the app's `commerce-app.json` inside the ZIP.
+
 #### Computing `sha256`
 
 The `sha256` value must match the ZIP you are submitting. On **macOS**, you can generate it with:
@@ -170,7 +184,10 @@ On **Linux**, the equivalent is usually `sha256sum /path/to/zip`.
       "provider": "thirdParty",
       "version": "1.0.0",
       "zip": "avalara-tax-v1.0.0.zip",
-      "sha256": "492fb0bc3aa5c762c0209bd22375e14ed2af8f672b679d6105232a37fe726a4f"
+      "sha256": "492fb0bc3aa5c762c0209bd22375e14ed2af8f672b679d6105232a37fe726a4f",
+      "storefrontSupport": {
+        "sfnext": { "minVersion": "1.0.0" }
+      }
     }
   ]
 }
@@ -305,11 +322,14 @@ The `commerce-app.json` file inside your ZIP must match the root manifest entry:
     "url": "https://developer.avalara.com/",
     "support": "https://developer.avalara.com/"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "storefrontSupport": {        // Optional - include only if declaring version requirements
+    "sfnext": { "minVersion": "1.0.0" }
+  }
 }
 ```
 
-**Critical:** The `version` field in `commerce-app.json` **must** match the `version` in the root manifest (`commerce-apps-manifest/manifest.json`).
+**Critical:** The `version` field in `commerce-app.json` **must** match the `version` in the root manifest (`commerce-apps-manifest/manifest.json`). If `storefrontSupport` is present in the root manifest, it must also be present with matching values in `commerce-app.json`.
 
 ---
 


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
- Add optional `storefrontSupport.sfnext.minVersion` / `maxVersion` semver fields to the commerce app manifest schema, enabling ISVs to declare minimum (and optional maximum) SFNext version compatibility                                       
- Add `validate_semver()` helper to `root-manifest-utils.sh` and a new verify-zip Step 8 that validates semver format, rejects unknown keys, and cross-validates values between the root manifest and `commerce-app.json`                         
- Add CI test suite (`test-root-manifest-utils.sh`, `test-security-scan.sh`) with a runner, plus a `test-scripts.yml` workflow that enforces test coverage for new scripts                                                                        
                                                                                                                                                                                                                                                    
## Details                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                    
Apps may declare `sfnext`, `sfra`, or both inside `storefrontSupport`. `minVersion` is required when the storefront key is present; `maxVersion` is optional (absence means no upper bound). Existing manifests without the field continue to pass validation unchanged.
                                                                                                                                                                                                                                            Updated documentation in CONTRIBUTING.md, AGENTS.md, and the `package-app`, `scaffold-app`, and `validate-app` skills.                                                                                                                            
  
## Test plan                                                                                                                                                                                                                                      
                                                                                                                                     
- [x] Run `.github/scripts/run-all-tests.sh` locally, all suites pass