### PR TITLE
Update testing doc: focus on CAP install workflow and b2c CLI

### DIFF
--- a/.claude/skills/validate-impex/SKILL.md
+++ b/.claude/skills/validate-impex/SKILL.md
@@ -49,6 +49,30 @@ find impex/ -name "*.xml" -exec xmllint --noout {} \;
 - Missing XML declaration
 - Invalid attribute quotes
 
+### XSD schema validation (preferred)
+
+If the `b2c` CLI is available, validate against the bundled SFCC XSD schemas — this catches namespace, structural, and type errors that plain well-formedness misses:
+
+```bash
+# List bundled schemas
+b2c docs schema --list
+
+# Validate site preferences and custom object metadata
+xmllint --schema "$(b2c docs schema metadata --path)" \
+  impex/install/meta/system-objecttype-extensions.xml --noout
+xmllint --schema "$(b2c docs schema metadata --path)" \
+  impex/install/meta/custom-objecttype-definitions.xml --noout
+
+# Validate services
+xmllint --schema "$(b2c docs schema services --path)" impex/install/services.xml --noout
+xmllint --schema "$(b2c docs schema services --path)" impex/uninstall/services.xml --noout
+
+# Validate preferences
+xmllint --schema "$(b2c docs schema preferences --path)" impex/install/preferences.xml --noout
+```
+
+If `b2c` is not installed globally, use `npx @salesforce/b2c-cli docs schema ...` instead.
+
 ## Step 3: Validate services.xml
 
 ### Installation file (`impex/install/services.xml`)

--- a/.claude/skills/validate-impex/SKILL.md
+++ b/.claude/skills/validate-impex/SKILL.md
@@ -51,7 +51,7 @@ find impex/ -name "*.xml" -exec xmllint --noout {} \;
 
 ### XSD schema validation (preferred)
 
-If the `b2c` CLI is available, validate against the bundled SFCC XSD schemas — this catches namespace, structural, and type errors that plain well-formedness misses:
+Validate against the bundled SFCC XSD schemas — this catches namespace, structural, and type errors that plain well-formedness misses. The `b2c` CLI ships the schemas; use `npx @salesforce/b2c-cli` if it's not installed globally.
 
 ```bash
 # List bundled schemas
@@ -70,8 +70,6 @@ xmllint --schema "$(b2c docs schema services --path)" impex/uninstall/services.x
 # Validate preferences
 xmllint --schema "$(b2c docs schema preferences --path)" impex/install/preferences.xml --noout
 ```
-
-If `b2c` is not installed globally, use `npx @salesforce/b2c-cli docs schema ...` instead.
 
 ## Step 3: Validate services.xml
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -82,24 +82,11 @@ Key commands referenced in this guide:
 
 > **Safety:** Set `SFCC_SAFETY_LEVEL=NO_DELETE` (or `READ_ONLY`) in shared/CI environments to block destructive operations. See the [Safety Mode docs](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/safety).
 
-### Claude Code Skills
+### Agent Skills
 
-This repository ships skills that automate the registry workflow. Invoke them by name from Claude Code:
+This repository ships the `cap-dev` plugin — a set of agent skills that automate the registry workflow (`scaffold-app`, `generate-*-impex`, `validate-impex`, `package-app`, `validate-app`, `submit-app`). See the [Agent Skills section in the README](../README.md#agent-skills) for installation and the full skill list.
 
-| Skill | Use when |
-|-------|----------|
-| `/scaffold-app` | Starting a new app — generates the directory structure and templates |
-| `/generate-service-impex` | Creating service credential / profile / definition impex (install + uninstall) |
-| `/generate-site-preferences-impex` | Adding merchant-configurable site preferences |
-| `/generate-custom-object-impex` | Adding custom object types for storage/caching |
-| `/validate-impex` | Validating impex XML syntax, namespaces, and install/uninstall pairing |
-| `/package-app` | Packaging a directory into a registry-ready ZIP and updating SHA256 in `manifest.json` |
-| `/validate-app` | Pre-submission validation — ZIP structure, manifest, hash, impex, security |
-| `/submit-app` | Opening the registry PR with the correct format and checklist |
-
-The skills layer on top of the `b2c` CLI — both `b2c cap validate` and `/validate-app` are appropriate, but `/validate-app` adds the registry-specific checks (manifest entry, SHA256 against `commerce-apps-manifest/manifest.json`, icon hash policy, etc.).
-
-> **Tip:** B2C platform skills (`b2c-code`, `b2c-logs`, `b2c-sandbox`, `b2c-job`, etc.) are also available if installed via `b2c setup install-skills`. They wrap the corresponding CLI commands for agent-driven workflows.
+Once installed, this guide refers to skills by their slash-command form (`/validate-impex`, `/validate-app`, `/package-app`, etc.). They layer on top of the `b2c` CLI — `/validate-app` adds the registry-specific checks (manifest entry, SHA256 against `commerce-apps-manifest/manifest.json`, icon hash policy) on top of `b2c cap validate`.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -31,6 +31,22 @@ The recommended workflow uses the [`b2c` CLI](#tooling) together with the Claude
 - A WebDAV access key (Account Manager → Profile → Application access keys → WebDAV)
 - An OCAPI/Account Manager API client with the permissions required by the commands you plan to run (see the [Authentication Guide](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/authentication))
 
+### B2C DX VS Code Extension (recommended IDE)
+
+The [B2C DX VS Code extension](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/) is the recommended replacement for Prophet and UX Studio for app development. It runs the same `b2c` CLI under the hood, so any auth or plugin you've configured for the CLI applies in the editor as well.
+
+Most useful for app development:
+
+- **Cartridge upload + watch** — edit locally, changes sync to the active code version automatically. Replaces `dwupload` / Prophet auto-upload.
+- **B2C Script Debugger** — set breakpoints in cartridge controllers, jobs, hooks, and Custom SCAPI API scripts; step through, watch variables, drop log points. Essential for debugging tax/shipping/payment hooks.
+- **CAP-aware tooling** — the extension uses the same CAP commands documented here (`cap validate`, `cap install`, `cap list`, etc.) and surfaces them in the UI.
+- **WebDAV browser** — open and edit `Impex/`, `Logs/`, and catalog files like local files.
+- **SCAPI API Explorer** — try Shopper and Admin APIs from a built-in Swagger UI with auth handled.
+- **Log tailing** — stream `error-*.log`, `warn-*.log`, and custom logs into a VS Code output channel.
+- **Sandbox Realm Explorer** — start/stop/clone/delete on-demand sandboxes from a tree view.
+
+Install per the [extension installation docs](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/installation). The extension is a developer preview — file issues at the [b2c-developer-tooling repo](https://github.com/SalesforceCommerceCloud/b2c-developer-tooling).
+
 ### `b2c` CLI
 
 The [`b2c` CLI](https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/) is the primary tool for testing apps against a sandbox. Install it once and authenticate via environment variables.
@@ -280,6 +296,10 @@ b2c code deploy -c int_myapp -c plugin_myapp_storefront
 
 ### Live-reload during development
 
+The [B2C DX VS Code extension](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/) provides the most ergonomic option — open the cartridge folder, connect to your sandbox, and changes upload automatically as you save (the modern replacement for Prophet's auto-upload).
+
+For a CLI equivalent:
+
 ```bash
 b2c code watch ./commerce-my-app-app-v1.0.0/cartridges
 ```
@@ -304,6 +324,8 @@ Trigger the hook (e.g., add to cart for tax calc) and watch logs:
 ```bash
 b2c logs tail --filter customerror --filter customwarn --filter custominfo --search myapp
 ```
+
+For interactive debugging — stepping through hook execution, inspecting `basket`/`order` state, watching variables — use the **B2C Script Debugger** in the [VS Code extension](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/). It supports breakpoints, log points, and step-through for cartridge controllers, jobs, hooks, and Custom SCAPI API scripts.
 
 ### Run unit tests
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -85,7 +85,7 @@ If you're using a coding agent (Claude Code, Cursor, GitHub Copilot, Codex), thi
 
 - `scaffold-app` — generates a new app directory from templates (UI-only / backend-only / fullstack)
 - `generate-service-impex`, `generate-site-preferences-impex`, `generate-custom-object-impex` — generate impex XML from prompts
-- `validate-impex` — checks impex XML for syntax, namespaces, install/uninstall pairing, ID conventions, and hardcoded credentials
+- `validate-impex` — checks impex XML for syntax, namespaces, install/uninstall pairing, ID conventions, and hardcoded credentials; pair with `b2c docs schema --path` + `xmllint --schema` (see [Impex validation](#impex-validation)) for XSD validation against the bundled SFCC schemas
 - `validate-app` — registry-specific checks: SHA256 against `commerce-apps-manifest/manifest.json`, manifest fields, icon hash, translations, security scan
 - `package-app` — builds the ZIP and updates the registry manifest entry
 - `submit-app` — opens the registry PR with the correct template via `gh`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 
 This guide explains how to test your Commerce App locally before submitting to the registry. For full documentation on designing, building, testing, and submitting Commerce apps, see the [developer guide](https://dpkoal18ck1fm.cloudfront.net/docs/commerce/b2c-commerce/guide/index.html).
 
-The recommended workflow uses the [`b2c` CLI](#tooling) — it covers cartridge upload, impex import, CAP install/uninstall, log inspection, and metadata validation against the SFCC XSDs in a single tool. If you're using a coding agent, the [`cap-dev` agent skills](#agent-skills-optional) shipped in this repository help with the packaging and submission steps (impex codegen, registry-specific validation, PR automation).
+The recommended workflow uses the [`b2c` CLI](#tooling) — it covers cartridge upload, impex import, CAP install/uninstall, log inspection, and metadata validation against the SFCC XSDs in a single tool. If you're using a coding agent, the [`cap-dev` agent skills](#agent-skills-optional) shipped in this repository add scaffolding, impex codegen, registry-specific validation, and PR automation on top.
 
 ---
 
@@ -81,16 +81,16 @@ Key commands referenced in this guide:
 
 ### Agent Skills (optional)
 
-If you're using a coding agent (Claude Code, Cursor, GitHub Copilot, Codex), this repository ships the `cap-dev` plugin — a set of skills focused on the packaging and submission steps:
+If you're using a coding agent (Claude Code, Cursor, GitHub Copilot, Codex), this repository ships the `cap-dev` plugin:
 
 - `scaffold-app` — generates a new app directory from templates (UI-only / backend-only / fullstack)
 - `generate-service-impex`, `generate-site-preferences-impex`, `generate-custom-object-impex` — generate impex XML from prompts
 - `validate-impex` — checks impex XML for syntax, namespaces, install/uninstall pairing, ID conventions, and hardcoded credentials
-- `validate-app` — runs registry-specific checks (SHA256 against `commerce-apps-manifest/manifest.json`, manifest fields, icon hash, translations, security scan) — complements rather than replaces `b2c cap validate`
+- `validate-app` — registry-specific checks: SHA256 against `commerce-apps-manifest/manifest.json`, manifest fields, icon hash, translations, security scan
 - `package-app` — builds the ZIP and updates the registry manifest entry
 - `submit-app` — opens the registry PR with the correct template via `gh`
 
-The skills don't cover the sandbox testing loop — for that, use the `b2c` CLI commands shown throughout this guide (`b2c cap install`, `b2c logs tail`, `b2c code watch`, etc.). See the [Agent Skills section in the README](../README.md#agent-skills) for installation.
+See the [Agent Skills section in the README](../README.md#agent-skills) for installation.
 
 ---
 
@@ -143,7 +143,7 @@ shasum -a 256 tax/my-app/my-app-v1.0.0.zip  # update manifest.json sha256 to mat
 #    Open a PR per CONTRIBUTING.md — commit only the ZIP, manifest.json, and (new apps) catalog.json
 ```
 
-> **Agent-driven equivalent:** with the `cap-dev` skills installed, the codegen and submission steps have shortcuts — `/validate-impex` and `/validate-app` for steps 2 and 4 (the latter adds registry-specific checks like SHA256 and translation verification), `/package-app` for step 4 (also updates the registry manifest entry), and `/submit-app` for step 5. The CLI commands above remain the canonical reference for the sandbox-testing portion of step 3.
+> **Agent-driven shortcuts:** with the `cap-dev` skills installed, `/validate-impex` and `/validate-app` cover steps 2 and 4 (the latter adds registry-specific checks like SHA256 and translation verification), `/package-app` builds the ZIP and updates the manifest entry, and `/submit-app` opens the PR.
 
 ### Complete Testing Checklist
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 
 This guide explains how to test your Commerce App locally before submitting to the registry. For full documentation on designing, building, testing, and submitting Commerce apps, see the [developer guide](https://dpkoal18ck1fm.cloudfront.net/docs/commerce/b2c-commerce/guide/index.html).
 
-The recommended workflow uses the [`b2c` CLI](#tooling) together with the Claude Code skills shipped in this repository. These automate the manual steps (cartridge upload, impex import, CAP install/uninstall, log inspection) that previously required UX Studio, Business Manager, or `xmllint` invocations by hand.
+The recommended workflow uses the [`b2c` CLI](#tooling) — it covers cartridge upload, impex import, CAP install/uninstall, log inspection, and metadata validation against the SFCC XSDs in a single tool. If you're using a coding agent, the [`cap-dev` agent skills](#agent-skills-optional) shipped in this repository wrap the same workflow.
 
 ---
 
@@ -33,13 +33,13 @@ The recommended workflow uses the [`b2c` CLI](#tooling) together with the Claude
 
 ### B2C DX VS Code Extension (recommended IDE)
 
-The [B2C DX VS Code extension](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/) is the recommended replacement for Prophet and UX Studio for app development. It runs the same `b2c` CLI under the hood, so any auth or plugin you've configured for the CLI applies in the editor as well.
+The [B2C DX VS Code extension](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/) provides an integrated development experience on top of the same `b2c` CLI. It picks up the same `dw.json` configuration, so configuring once works for both.
 
 Most useful for app development:
 
-- **Cartridge upload + watch** — edit locally, changes sync to the active code version automatically. Replaces `dwupload` / Prophet auto-upload.
-- **B2C Script Debugger** — set breakpoints in cartridge controllers, jobs, hooks, and Custom SCAPI API scripts; step through, watch variables, drop log points. Essential for debugging tax/shipping/payment hooks.
-- **CAP-aware tooling** — the extension uses the same CAP commands documented here (`cap validate`, `cap install`, `cap list`, etc.) and surfaces them in the UI.
+- **Cartridge upload + watch** — edit locally, changes sync to the active code version on save.
+- **B2C Script Debugger** — set breakpoints in cartridge controllers, jobs, hooks, and Custom SCAPI API scripts; step through, watch variables, drop log points.
+- **CAP-aware tooling** — surfaces `cap validate`, `cap install`, `cap list`, etc. in the UI.
 - **WebDAV browser** — open and edit `Impex/`, `Logs/`, and catalog files like local files.
 - **SCAPI API Explorer** — try Shopper and Admin APIs from a built-in Swagger UI with auth handled.
 - **Log tailing** — stream `error-*.log`, `warn-*.log`, and custom logs into a VS Code output channel.
@@ -79,49 +79,78 @@ Key commands referenced in this guide:
 
 > **Safety:** Set `SFCC_SAFETY_LEVEL=NO_DELETE` (or `READ_ONLY`) in shared/CI environments to block destructive operations. See the [Safety Mode docs](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/safety).
 
-### Agent Skills
+### Agent Skills (optional)
 
-This repository ships the `cap-dev` plugin — a set of agent skills that automate the registry workflow (`scaffold-app`, `generate-*-impex`, `validate-impex`, `package-app`, `validate-app`, `submit-app`). See the [Agent Skills section in the README](../README.md#agent-skills) for installation and the full skill list.
+If you're using a coding agent (Claude Code, Cursor, GitHub Copilot, Codex), this repository ships the `cap-dev` plugin — a set of agent skills that wrap the workflow steps below (`scaffold-app`, `generate-*-impex`, `validate-impex`, `package-app`, `validate-app`, `submit-app`). See the [Agent Skills section in the README](../README.md#agent-skills) for installation and the full skill list.
 
-Once installed, this guide refers to skills by their slash-command form (`/validate-impex`, `/validate-app`, `/package-app`, etc.). They layer on top of the `b2c` CLI — `/validate-app` adds the registry-specific checks (manifest entry, SHA256 against `commerce-apps-manifest/manifest.json`, icon hash policy) on top of `b2c cap validate`.
+Each step in this guide can be performed with the `b2c` CLI directly. Where a skill is a useful shortcut (e.g., `/validate-app` adds the registry-specific SHA256/manifest/icon checks on top of `b2c cap validate`), it's called out inline.
 
 ---
 
 ## Testing Workflow
 
 ```
-1. Develop  →  2. Validate impex  →  3. Package  →  4. Install on sandbox  →  5. Test  →  6. Validate ZIP  →  7. Submit
+1. Develop  →  2. Test Locally  →  3. Test in Sandbox  →  4. Validate  →  5. Submit
 ```
 
-The recommended loop for an existing app directory `tax/my-app/commerce-my-app-app-v1.0.0/`:
+For an app directory `tax/my-app/commerce-my-app-app-v1.0.0/`, run these commands in order:
 
 ```bash
-# 1. Validate impex while editing
-/validate-impex
+# 1. Develop — edit cartridges, impex, storefront-next/
 
-# 2. Package and validate the CAP
-b2c cap validate tax/my-app/commerce-my-app-app-v1.0.0
-b2c cap package  tax/my-app/commerce-my-app-app-v1.0.0 --output tax/my-app/
+# 2. Test locally
+#    Validate impex XML against the SFCC schemas
+xmllint --schema "$(b2c docs schema metadata --path)" \
+  impex/install/meta/system-objecttype-extensions.xml --noout
+xmllint --schema "$(b2c docs schema services --path)" impex/install/services.xml --noout
 
-# 3. Install on a sandbox site
-b2c cap install tax/my-app/commerce-my-app-app-v1.0.0.zip --site-id RefArch
+#    Run cartridge unit tests if present
+( cd cartridges/site_cartridges/int_myapp && npm install && npm test )
 
-# 4. Watch logs in another terminal
+#    Validate the CAP structure
+b2c cap validate ./commerce-my-app-app-v1.0.0
+
+# 3. Test in sandbox
+#    Install the CAP — this imports impex, deploys cartridges, registers the feature
+b2c cap install ./commerce-my-app-app-v1.0.0 --site-id RefArch
+
+#    Tail logs (run in a second terminal while exercising the storefront)
 b2c logs tail --filter customerror --filter error
 
-# 5. Iterate on cartridge code without re-installing the CAP
+#    Iterate on cartridge code without re-installing the CAP
 b2c code watch ./commerce-my-app-app-v1.0.0/cartridges
 
-# 6. Inspect installed feature state and post-install tasks
-b2c cap list --site-id RefArch
+#    Verify post-install tasks and complete them in Business Manager
 b2c cap tasks my-app --site-id RefArch
 
-# 7. Tear down before re-installing (or before testing the uninstall path)
+#    Confirm uninstall works cleanly
 b2c cap uninstall my-app --site-id RefArch
+b2c cap list --site-id RefArch  # confirm gone
 
-# 8. Final pre-submission validation
-/validate-app
+# 4. Validate the registry package
+b2c cap package ./commerce-my-app-app-v1.0.0 --output tax/my-app/
+b2c cap validate tax/my-app/my-app-v1.0.0.zip
+shasum -a 256 tax/my-app/my-app-v1.0.0.zip  # update manifest.json sha256 to match
+
+# 5. Submit
+#    Open a PR per CONTRIBUTING.md — commit only the ZIP, manifest.json, and (new apps) catalog.json
 ```
+
+> **Agent-driven equivalent:** with the `cap-dev` skills installed, steps 2 and 4 collapse to `/validate-impex`, `/validate-app`, and `/package-app`, and step 5 to `/submit-app`. The CLI commands above remain the canonical reference.
+
+### Complete Testing Checklist
+
+- [ ] Cartridges upload successfully (CAP install completes without errors)
+- [ ] Impex files import without errors (check `b2c job log sfcc-install-commerce-app --failed`)
+- [ ] Services authenticate and respond
+- [ ] Hooks execute correctly
+- [ ] UI components render properly (Storefront Next apps)
+- [ ] Site preferences are configurable in Business Manager
+- [ ] Custom objects store/retrieve data
+- [ ] No errors in `b2c logs get --since 1h --level ERROR`
+- [ ] Performance is acceptable
+- [ ] Uninstall path cleans up everything
+- [ ] `b2c cap validate` passes on the final ZIP
 
 ---
 
@@ -154,18 +183,20 @@ b2c cap validate ./commerce-my-app-app-v1.0.0 --json
 
 ### Registry-level validation
 
-`/validate-app` adds checks that only apply when submitting to this registry:
+In addition to `b2c cap validate`, the registry has a few rules that aren't enforced by the install job:
 
 - ZIP at the correct `{domain}/{appName}/` path
-- SHA256 in `commerce-apps-manifest/manifest.json` matches the actual hash
+- SHA256 in `commerce-apps-manifest/manifest.json` matches the actual hash (`shasum -a 256 <zip>`)
 - `manifest.json` has all required fields (`id`, `name`, `iconName`, `domain`, `type=app`, `provider=thirdParty`, `version`, `zip`, `sha256`)
 - `storefrontSupport` (if present) has matching values in root `manifest.json` **and** `commerce-app.json`
 - No junk files in the ZIP (`.DS_Store`, `__MACOSX/*`, hidden files)
 - Single root folder named `commerce-{appName}-app-v{version}/`
 
+The `cap-dev` plugin's `/validate-app` skill bundles all of these checks if you're using a coding agent.
+
 ### Impex validation
 
-`/validate-impex` (also runs as part of `/validate-app`) handles XML:
+Beyond `b2c cap validate`, validate the XML directly:
 
 - Well-formed XML for every file under `impex/`
 - Correct SFCC namespaces (`http://www.demandware.com/xml/impex/services/2015-07-01`, etc.)
@@ -175,7 +206,7 @@ b2c cap validate ./commerce-my-app-app-v1.0.0 --json
 - `SITEID` placeholder used in `preferences.xml` (not a real site ID)
 - No hardcoded production credentials
 
-For deeper validation against the official SFCC XSD schemas, the `b2c` CLI ships them — pair `b2c docs schema --path` with `xmllint --schema`:
+The `b2c` CLI bundles the SFCC XSD schemas — pair `b2c docs schema --path` with `xmllint --schema`:
 
 ```bash
 # List bundled schemas
@@ -280,15 +311,13 @@ b2c code deploy -c int_myapp -c plugin_myapp_storefront
 
 ### Live-reload during development
 
-The [B2C DX VS Code extension](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/) provides the most ergonomic option — open the cartridge folder, connect to your sandbox, and changes upload automatically as you save (the modern replacement for Prophet's auto-upload).
-
-For a CLI equivalent:
-
 ```bash
 b2c code watch ./commerce-my-app-app-v1.0.0/cartridges
 ```
 
 Press `Ctrl+C` to stop. File adds/changes are batched and uploaded; deletions are removed from the server.
+
+The [B2C DX VS Code extension](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/) provides the same behavior integrated into the editor — open the cartridge folder, connect to your sandbox, and changes upload on save.
 
 ### Verify cartridge path
 
@@ -330,10 +359,10 @@ npm test
 ### Recommended development loop
 
 ```bash
-# 1. Validate impex syntax + structure first
-/validate-impex
+# 1. Validate impex XML well-formedness
+find impex/ -name "*.xml" -exec xmllint --noout {} \;
 
-# 2. Validate against the SFCC XSDs (optional but catches most schema errors)
+# 2. Validate against the SFCC XSDs (catches most schema errors)
 xmllint --schema "$(b2c docs schema metadata --path)" \
   impex/install/meta/system-objecttype-extensions.xml --noout
 xmllint --schema "$(b2c docs schema services --path)" impex/install/services.xml --noout
@@ -638,7 +667,7 @@ Suggested targets:
 
 Administration → Operations → Services → Service Monitoring shows averages and per-call timing. Optimize by:
 
-- Caching responses in a custom object (use `/generate-custom-object-impex` for the type definition)
+- Caching responses in a custom object
 - Reducing payload size
 - Tightening timeouts so failures fail fast
 - Confirming the circuit breaker thresholds on the service profile
@@ -659,12 +688,12 @@ Verify TTL by waiting past the configured window and confirming a fresh service 
 
 ## Pre-Submission Checklist
 
-Before opening the PR (use `/submit-app` to drive this):
+Before opening the PR:
 
 **Validation:**
-- [ ] `/validate-impex` passes
-- [ ] `b2c cap validate <path>` passes
-- [ ] `/validate-app` passes (covers manifest, SHA256, structure, security)
+- [ ] All impex XML is well-formed and validates against the SFCC XSDs (`xmllint --schema "$(b2c docs schema <name> --path)" ...`)
+- [ ] `b2c cap validate <zip>` passes
+- [ ] SHA256 in `manifest.json` matches the ZIP (`shasum -a 256 <zip>`)
 
 **Files committed:**
 - [ ] `{domain}/{appName}/{appName}-v{version}.zip`
@@ -704,11 +733,11 @@ Before opening the PR (use `/submit-app` to drive this):
 Run `b2c cap validate` to see the specific rule violation. Most commonly: missing `commerce-app.json` field, invalid semver, missing `tasksList.json`, or pipeline files left in cartridges.
 
 ### Impex import errors
-- Run `/validate-impex` first
+- Validate against the SFCC XSDs: `xmllint --schema "$(b2c docs schema metadata --path)" <file> --noout`
 - Check for unescaped `&` or `<` in XML (`&amp;` / `&lt;`)
 - Confirm namespaces match the SFCC schema (e.g., `services/2015-07-01`)
-- Replace `SITEID` with the actual site ID only via `preferences.xml` substitution — never commit a real site ID
-- Get the failing job's log: `b2c job log sfcc-site-archive-import --failed`
+- `SITEID` placeholder in `preferences.xml` should be substituted at install time — never commit a real site ID
+- Get the failing job's log: `b2c job log sfcc-install-commerce-app --failed`
 
 ### Service call fails
 - Verify credentials are sandbox/test values, not production
@@ -729,17 +758,17 @@ Run `b2c cap validate` to see the specific rule violation. Most commonly: missin
 - Test the component in isolation (Storybook) to rule out target/data issues
 
 ### SHA256 mismatch on PR
-The hash in `manifest.json` doesn't match the ZIP. Run `/package-app` (or recompute manually with `shasum -a 256`) and commit the updated manifest.
+The hash in `manifest.json` doesn't match the ZIP. Recompute with `shasum -a 256 <zip>` and update `manifest.json`.
 
 ---
 
 ## Best Practices
 
-- **Test as you build.** Validate impex on every change with `/validate-impex`. Tail logs in a side terminal during development.
+- **Test as you build.** Validate impex against the SFCC XSDs on every change. Tail logs in a side terminal during development.
 - **Use a dedicated sandbox.** Don't share with someone else's in-progress work, and never test on production.
 - **Test the uninstall path.** A clean uninstall is a release requirement, not an afterthought.
-- **Automate validation.** Wire `b2c cap validate` and the impex validator into CI for app repos that live outside this registry.
-- **Keep credentials out of the repo.** Use `.envrc`, direnv, or your shell profile for `SFCC_*` variables — never commit them.
+- **Automate validation.** Wire `b2c cap validate` and `xmllint --schema` checks into CI for app repos that live outside this registry.
+- **Keep credentials out of the repo.** Configure `dw.json` outside the project (or `.gitignore` it) — never commit credentials.
 
 ---
 
@@ -751,5 +780,5 @@ The hash in `manifest.json` doesn't match the ZIP. Run `/package-app` (or recomp
    - [SFCC Documentation](https://developer.salesforce.com/docs/commerce/b2c-commerce)
    - [CONTRIBUTING.md](../CONTRIBUTING.md)
    - [AGENTS.md](../AGENTS.md) — guidance for AI assistants in this repo
-3. **Validation skills:** `/validate-app`, `/validate-impex`
-4. **Reference app:** `tax/avalara-tax/` — a working CAP with cartridges, hooks, impex, and unit tests
+3. **Reference app:** `tax/avalara-tax/` — a working CAP with cartridges, hooks, impex, and unit tests
+4. **Agent skills:** see the [Agent Skills section in the README](../README.md#agent-skills) if you'd like an agent to drive validation/packaging/submission

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,7 +2,7 @@
 
 This guide explains how to test your Commerce App locally before submitting to the registry. For full documentation on designing, building, testing, and submitting Commerce apps, see the [developer guide](https://dpkoal18ck1fm.cloudfront.net/docs/commerce/b2c-commerce/guide/index.html).
 
-The recommended workflow uses the [`b2c` CLI](#tooling) — it covers cartridge upload, impex import, CAP install/uninstall, log inspection, and metadata validation against the SFCC XSDs in a single tool. If you're using a coding agent, the [`cap-dev` agent skills](#agent-skills-optional) shipped in this repository wrap the same workflow.
+The recommended workflow uses the [`b2c` CLI](#tooling) — it covers cartridge upload, impex import, CAP install/uninstall, log inspection, and metadata validation against the SFCC XSDs in a single tool. If you're using a coding agent, the [`cap-dev` agent skills](#agent-skills-optional) shipped in this repository help with the packaging and submission steps (impex codegen, registry-specific validation, PR automation).
 
 ---
 
@@ -81,9 +81,16 @@ Key commands referenced in this guide:
 
 ### Agent Skills (optional)
 
-If you're using a coding agent (Claude Code, Cursor, GitHub Copilot, Codex), this repository ships the `cap-dev` plugin — a set of agent skills that wrap the workflow steps below (`scaffold-app`, `generate-*-impex`, `validate-impex`, `package-app`, `validate-app`, `submit-app`). See the [Agent Skills section in the README](../README.md#agent-skills) for installation and the full skill list.
+If you're using a coding agent (Claude Code, Cursor, GitHub Copilot, Codex), this repository ships the `cap-dev` plugin — a set of skills focused on the packaging and submission steps:
 
-Each step in this guide can be performed with the `b2c` CLI directly. Where a skill is a useful shortcut (e.g., `/validate-app` adds the registry-specific SHA256/manifest/icon checks on top of `b2c cap validate`), it's called out inline.
+- `scaffold-app` — generates a new app directory from templates (UI-only / backend-only / fullstack)
+- `generate-service-impex`, `generate-site-preferences-impex`, `generate-custom-object-impex` — generate impex XML from prompts
+- `validate-impex` — checks impex XML for syntax, namespaces, install/uninstall pairing, ID conventions, and hardcoded credentials
+- `validate-app` — runs registry-specific checks (SHA256 against `commerce-apps-manifest/manifest.json`, manifest fields, icon hash, translations, security scan) — complements rather than replaces `b2c cap validate`
+- `package-app` — builds the ZIP and updates the registry manifest entry
+- `submit-app` — opens the registry PR with the correct template via `gh`
+
+The skills don't cover the sandbox testing loop — for that, use the `b2c` CLI commands shown throughout this guide (`b2c cap install`, `b2c logs tail`, `b2c code watch`, etc.). See the [Agent Skills section in the README](../README.md#agent-skills) for installation.
 
 ---
 
@@ -136,7 +143,7 @@ shasum -a 256 tax/my-app/my-app-v1.0.0.zip  # update manifest.json sha256 to mat
 #    Open a PR per CONTRIBUTING.md — commit only the ZIP, manifest.json, and (new apps) catalog.json
 ```
 
-> **Agent-driven equivalent:** with the `cap-dev` skills installed, steps 2 and 4 collapse to `/validate-impex`, `/validate-app`, and `/package-app`, and step 5 to `/submit-app`. The CLI commands above remain the canonical reference.
+> **Agent-driven equivalent:** with the `cap-dev` skills installed, the codegen and submission steps have shortcuts — `/validate-impex` and `/validate-app` for steps 2 and 4 (the latter adds registry-specific checks like SHA256 and translation verification), `/package-app` for step 4 (also updates the registry manifest entry), and `/submit-app` for step 5. The CLI commands above remain the canonical reference for the sandbox-testing portion of step 3.
 
 ### Complete Testing Checklist
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -213,7 +213,7 @@ Beyond `b2c cap validate`, validate the XML directly:
 - `SITEID` placeholder used in `preferences.xml` (not a real site ID)
 - No hardcoded production credentials
 
-The `b2c` CLI bundles the SFCC XSD schemas — pair `b2c docs schema --path` with `xmllint --schema`:
+The `b2c` CLI bundles the SFCC XSD schemas — pair `b2c docs schema --path` with `xmllint --schema`. If `b2c` isn't installed globally, swap in `npx @salesforce/b2c-cli` anywhere `b2c` appears:
 
 ```bash
 # List bundled schemas

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -81,14 +81,14 @@ Key commands referenced in this guide:
 
 ### Agent Skills (optional)
 
-If you're using a coding agent (Claude Code, Cursor, GitHub Copilot, Codex), this repository ships the `cap-dev` plugin:
+If you're using a coding agent (Claude Code, Cursor, GitHub Copilot, Codex), this repository ships the `cap-dev` plugin. Each skill gives the agent the context to perform a specific part of the workflow:
 
-- `scaffold-app` — generates a new app directory from templates (UI-only / backend-only / fullstack)
-- `generate-service-impex`, `generate-site-preferences-impex`, `generate-custom-object-impex` — generate impex XML from prompts
-- `validate-impex` — checks impex XML for syntax, namespaces, install/uninstall pairing, ID conventions, and hardcoded credentials; pair with `b2c docs schema --path` + `xmllint --schema` (see [Impex validation](#impex-validation)) for XSD validation against the bundled SFCC schemas
-- `validate-app` — registry-specific checks: SHA256 against `commerce-apps-manifest/manifest.json`, manifest fields, icon hash, translations, security scan
-- `package-app` — builds the ZIP and updates the registry manifest entry
-- `submit-app` — opens the registry PR with the correct template via `gh`
+- `scaffold-app` — guidance for generating a new app directory (UI-only / backend-only / fullstack), including the templates and conventions
+- `generate-service-impex`, `generate-site-preferences-impex`, `generate-custom-object-impex` — guidance for producing impex XML, covering schema, namespaces, IDs, and install/uninstall pairing
+- `validate-impex` — guidance for impex validation, covering syntax, namespaces, install/uninstall pairing, ID conventions, hardcoded credentials, and XSD validation against the bundled SFCC schemas via `b2c docs schema --path`
+- `validate-app` — guidance for registry-specific validation: SHA256 against `commerce-apps-manifest/manifest.json`, manifest fields, icon hash, translations, security scan
+- `package-app` — guidance for building the ZIP and updating the registry manifest entry
+- `submit-app` — guidance for opening the registry PR with the correct template
 
 See the [Agent Skills section in the README](../README.md#agent-skills) for installation.
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -2,223 +2,425 @@
 
 This guide explains how to test your Commerce App locally before submitting to the registry. For full documentation on designing, building, testing, and submitting Commerce apps, see the [developer guide](https://dpkoal18ck1fm.cloudfront.net/docs/commerce/b2c-commerce/guide/index.html).
 
+The recommended workflow uses the [`b2c` CLI](#tooling) together with the Claude Code skills shipped in this repository. These automate the manual steps (cartridge upload, impex import, CAP install/uninstall, log inspection) that previously required UX Studio, Business Manager, or `xmllint` invocations by hand.
+
 ---
 
 ## Table of Contents
 
-- [Prerequisites](#prerequisites)
+- [Tooling](#tooling)
 - [Testing Workflow](#testing-workflow)
+- [Validating the App Package](#validating-the-app-package)
+- [Installing on a Sandbox](#installing-on-a-sandbox)
 - [Testing Cartridges](#testing-cartridges)
 - [Testing Impex Files](#testing-impex-files)
 - [Testing UI Components](#testing-ui-components)
 - [Testing Services](#testing-services)
+- [Inspecting Logs](#inspecting-logs)
 - [End-to-End Testing](#end-to-end-testing)
 - [Performance Testing](#performance-testing)
-- [Validation Before Submission](#validation-before-submission)
+- [Pre-Submission Checklist](#pre-submission-checklist)
+- [Common Testing Issues](#common-testing-issues)
 
 ---
 
-## Prerequisites
+## Tooling
 
 ### Required Access
-- SFCC Sandbox environment (Account Manager or Business Manager access)
-- UX Studio or VS Code with Prophet extension
-- Node.js and npm (for frontend testing)
+- A B2C Commerce sandbox (On-Demand Sandbox or partner sandbox)
+- A WebDAV access key (Account Manager → Profile → Application access keys → WebDAV)
+- An OCAPI/Account Manager API client with the permissions required by the commands you plan to run (see the [Authentication Guide](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/authentication))
 
-### Recommended Tools
-- **xmllint** - Validate XML impex files
-- **Postman** - Test service endpoints
-- **Chrome DevTools** - Debug frontend components
-- **Claude Code** - Use validation skills
+### `b2c` CLI
+
+The [`b2c` CLI](https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/) is the primary tool for testing apps against a sandbox. Install it once and authenticate via environment variables.
+
+```bash
+# Install
+npm install -g @salesforce/b2c-cli
+# or use without install: npx @salesforce/b2c-cli ...
+
+# Configure once per shell (or use a .envrc / direnv)
+export SFCC_SERVER=my-sandbox.demandware.net
+export SFCC_USERNAME=my-bm-user
+export SFCC_PASSWORD=my-webdav-access-key
+export SFCC_CLIENT_ID=my-client
+export SFCC_CLIENT_SECRET=my-secret
+export SFCC_CODE_VERSION=version1
+```
+
+Key commands referenced in this guide:
+
+| Command | Purpose |
+|---------|---------|
+| `b2c cap validate <path>` | Validate CAP structure (manifest, required files, no pipelines, etc.) |
+| `b2c cap package <path>` | Package a directory into a `.zip` |
+| `b2c cap install <path> -s <site>` | Install a CAP on a sandbox site (uploads + runs `sfcc-install-commerce-app`) |
+| `b2c cap uninstall <id> -s <site>` | Uninstall a CAP from a site |
+| `b2c cap list` / `cap tasks` | Inspect installed features and post-install tasks |
+| `b2c code deploy` / `code watch` | Deploy or live-sync cartridges via WebDAV |
+| `b2c job import <path>` | Import a site archive (impex) via `sfcc-site-archive-import` |
+| `b2c job run <id> --wait` | Execute and wait on a job |
+| `b2c logs tail` / `logs get` | Stream or fetch instance logs (custom logs, errors, etc.) |
+| `b2c sandbox list` / `sandbox start` | Manage On-Demand Sandboxes |
+
+> **Safety:** Set `SFCC_SAFETY_LEVEL=NO_DELETE` (or `READ_ONLY`) in shared/CI environments to block destructive operations. See the [Safety Mode docs](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/safety).
+
+### Claude Code Skills
+
+This repository ships skills that automate the registry workflow. Invoke them by name from Claude Code:
+
+| Skill | Use when |
+|-------|----------|
+| `/scaffold-app` | Starting a new app — generates the directory structure and templates |
+| `/generate-service-impex` | Creating service credential / profile / definition impex (install + uninstall) |
+| `/generate-site-preferences-impex` | Adding merchant-configurable site preferences |
+| `/generate-custom-object-impex` | Adding custom object types for storage/caching |
+| `/validate-impex` | Validating impex XML syntax, namespaces, and install/uninstall pairing |
+| `/package-app` | Packaging a directory into a registry-ready ZIP and updating SHA256 in `manifest.json` |
+| `/validate-app` | Pre-submission validation — ZIP structure, manifest, hash, impex, security |
+| `/submit-app` | Opening the registry PR with the correct format and checklist |
+
+The skills layer on top of the `b2c` CLI — both `b2c cap validate` and `/validate-app` are appropriate, but `/validate-app` adds the registry-specific checks (manifest entry, SHA256 against `commerce-apps-manifest/manifest.json`, icon hash policy, etc.).
+
+> **Tip:** B2C platform skills (`b2c-code`, `b2c-logs`, `b2c-sandbox`, `b2c-job`, etc.) are also available if installed via `b2c setup install-skills`. They wrap the corresponding CLI commands for agent-driven workflows.
 
 ---
 
 ## Testing Workflow
 
 ```
-1. Develop → 2. Test Locally → 3. Test in Sandbox → 4. Validate → 5. Submit
+1. Develop  →  2. Validate impex  →  3. Package  →  4. Install on sandbox  →  5. Test  →  6. Validate ZIP  →  7. Submit
 ```
 
-### Complete Testing Checklist
+The recommended loop for an existing app directory `tax/my-app/commerce-my-app-app-v1.0.0/`:
 
-- [ ] Cartridges upload successfully
-- [ ] Impex files import without errors
-- [ ] Services authenticate and respond
-- [ ] Hooks execute correctly
-- [ ] UI components render properly
-- [ ] Site preferences are configurable
-- [ ] Custom objects store/retrieve data
-- [ ] No errors in logs
-- [ ] Performance is acceptable
-- [ ] Validation passes
+```bash
+# 1. Validate impex while editing
+/validate-impex
+
+# 2. Package and validate the CAP
+b2c cap validate tax/my-app/commerce-my-app-app-v1.0.0
+b2c cap package  tax/my-app/commerce-my-app-app-v1.0.0 --output tax/my-app/
+
+# 3. Install on a sandbox site
+b2c cap install tax/my-app/commerce-my-app-app-v1.0.0.zip --site-id RefArch
+
+# 4. Watch logs in another terminal
+b2c logs tail --filter customerror --filter error
+
+# 5. Iterate on cartridge code without re-installing the CAP
+b2c code watch ./commerce-my-app-app-v1.0.0/cartridges
+
+# 6. Inspect installed feature state and post-install tasks
+b2c cap list --site-id RefArch
+b2c cap tasks my-app --site-id RefArch
+
+# 7. Tear down before re-installing (or before testing the uninstall path)
+b2c cap uninstall my-app --site-id RefArch
+
+# 8. Final pre-submission validation
+/validate-app
+```
+
+---
+
+## Validating the App Package
+
+Run validation **before** installing on a sandbox to catch structural issues early.
+
+### CAP structural validation
+
+`b2c cap validate` checks the rules enforced by the install job:
+
+- `commerce-app.json` exists and has `id`, `name`, `version`, `domain`
+- `version` is valid semver
+- `app-configuration/tasksList.json` exists and is a JSON array with `taskNumber`, `name`, `description`, `link` per task
+- At least one of `cartridges/`, `storefront-next/`, or `impex/` is present
+- No `pipeline/` directories or `*.ds` pipeline descriptor files
+- Site cartridges (`cartridges/site_cartridges/`) contain no `controllers/`
+- `README.md` exists
+
+```bash
+# From a directory
+b2c cap validate ./commerce-my-app-app-v1.0.0
+
+# From a ZIP
+b2c cap validate ./my-app-v1.0.0.zip
+
+# Machine-readable
+b2c cap validate ./commerce-my-app-app-v1.0.0 --json
+```
+
+### Registry-level validation
+
+`/validate-app` adds checks that only apply when submitting to this registry:
+
+- ZIP at the correct `{domain}/{appName}/` path
+- SHA256 in `commerce-apps-manifest/manifest.json` matches the actual hash
+- `manifest.json` has all required fields (`id`, `name`, `iconName`, `domain`, `type=app`, `provider=thirdParty`, `version`, `zip`, `sha256`)
+- `storefrontSupport` (if present) has matching values in root `manifest.json` **and** `commerce-app.json`
+- No junk files in the ZIP (`.DS_Store`, `__MACOSX/*`, hidden files)
+- Single root folder named `commerce-{appName}-app-v{version}/`
+
+### Impex validation
+
+`/validate-impex` (also runs as part of `/validate-app`) handles XML:
+
+- Well-formed XML for every file under `impex/`
+- Correct SFCC namespaces (`http://www.demandware.com/xml/impex/services/2015-07-01`, etc.)
+- `mode="delete"` on every entry in `impex/uninstall/`
+- Service IDs in install match uninstall, deletion order is service → profile → credential
+- Attribute IDs are camelCase and prefixed with the app name
+- `SITEID` placeholder used in `preferences.xml` (not a real site ID)
+- No hardcoded production credentials
+
+For deeper validation against the official SFCC XSD schemas, the `b2c` CLI ships them — pair `b2c docs schema --path` with `xmllint --schema`:
+
+```bash
+# List bundled schemas
+b2c docs schema --list
+
+# Validate site preferences and custom object metadata against the metadata schema
+xmllint --schema "$(b2c docs schema metadata --path)" \
+  impex/install/meta/system-objecttype-extensions.xml --noout
+
+xmllint --schema "$(b2c docs schema metadata --path)" \
+  impex/install/meta/custom-objecttype-definitions.xml --noout
+
+# Validate services
+xmllint --schema "$(b2c docs schema services --path)" impex/install/services.xml --noout
+
+# Validate preferences (after substituting SITEID)
+xmllint --schema "$(b2c docs schema preferences --path)" impex/install/preferences.xml --noout
+```
+
+For a quick well-formedness check without schema validation:
+
+```bash
+find impex/ -name "*.xml" -exec xmllint --noout {} \;
+```
+
+---
+
+## Installing on a Sandbox
+
+### Install the CAP
+
+The supported way to install a CAP is via the `sfcc-install-commerce-app` system job, which `b2c cap install` triggers:
+
+```bash
+# Install from a ZIP or directory (directories are zipped automatically)
+b2c cap install tax/my-app/commerce-my-app-app-v1.0.0.zip --site-id RefArch
+
+# Skip pre-install validation (already validated separately)
+b2c cap install ./commerce-my-app-app-v1.0.0 -s RefArch --skip-validate
+
+# Remove the uploaded archive after install completes
+b2c cap install ./commerce-my-app-app-v1.0.0 -s RefArch --clean-archive
+```
+
+Behind the scenes the CLI uploads the ZIP to `Impex/commerce-apps/`, runs the install job, and waits for it to finish.
+
+### Verify installation
+
+```bash
+# Confirm the feature is registered for the site
+b2c cap list --site-id RefArch
+
+# View the post-install tasks (clickable Business Manager links)
+b2c cap tasks my-app --site-id RefArch
+```
+
+`cap list` shows install status, config status, version, source (`CUSTOM` for WebDAV upload, `REGISTRY` for App Registry), and timestamp.
+
+### Uninstall
+
+Always test the uninstall path in a sandbox before submitting:
+
+```bash
+b2c cap uninstall my-app --site-id RefArch
+```
+
+The CLI looks up the app's domain from the feature state and runs the appropriate cleanup.
+
+### Pulling installed apps back
+
+If you need to grab a CAP that's already installed (for inspection or to deploy cartridges to a code version), use:
+
+```bash
+# Pull every registry-installed app
+b2c cap pull
+
+# Pull a single app
+b2c cap pull my-app --site-id RefArch --output ./pulled-apps
+```
 
 ---
 
 ## Testing Cartridges
 
-### 1. Upload Cartridges to Sandbox
+For most apps the CAP install handles cartridge upload and adds them to the cartridge path. When iterating on cartridge code without rerunning the install, deploy directly to a code version.
 
-**Via UX Studio:**
-1. Right-click on cartridge → Upload to Server
-2. Verify upload completes successfully
-
-**Via dwupload (Prophet):**
-```bash
-cd cartridges/site_cartridges/my_cartridge
-npm run upload
-```
-
-**Via VS Code with Prophet:**
-1. Configure `.prophet.conf.json`
-2. Right-click cartridge → Upload
-
-### 2. Add to Cartridge Path
-
-1. Business Manager → Administration → Sites → Manage Sites
-2. Select your site → Settings tab
-3. Add cartridge to path (in correct order):
-   ```
-   int_myapp:site_genesis:other_cartridges
-   ```
-4. Save and verify
-
-### 3. Test Hooks
-
-**Verify hooks are registered:**
-```javascript
-// In your cartridge's hooks.json
-{
-  "hooks": [
-    {
-      "name": "sf.commerce.app.tax.calculate",
-      "script": "./hooks/calculate.js"
-    }
-  ]
-}
-```
-
-**Test hook execution:**
-- Trigger the hook in storefront (e.g., add to cart for tax calculation)
-- Check custom logs in Business Manager:
-  - Administration → Operations → Logs → Custom Logs
-  - Look for your app's log prefix
-
-**Debug hooks:**
-```javascript
-// Add debug logging
-var Logger = require('dw/system/Logger');
-var logger = Logger.getLogger('myApp', 'calculate');
-
-logger.debug('Hook triggered with params: {0}', JSON.stringify(params));
-```
-
-### 4. Run Unit Tests
-
-If your cartridge has unit tests:
+### Deploy cartridges directly
 
 ```bash
-cd cartridges/site_cartridges/my_cartridge
+# Deploy every cartridge under the current directory (cartridges discovered via .project files)
+b2c code deploy
+
+# Deploy to a specific code version
+b2c code deploy ./commerce-my-app-app-v1.0.0/cartridges --code-version version1
+
+# Deploy and reload (toggle activation to force reload of new code)
+b2c code deploy --reload
+
+# Deploy a subset
+b2c code deploy -c int_myapp -c plugin_myapp_storefront
+```
+
+### Live-reload during development
+
+```bash
+b2c code watch ./commerce-my-app-app-v1.0.0/cartridges
+```
+
+Press `Ctrl+C` to stop. File adds/changes are batched and uploaded; deletions are removed from the server.
+
+### Verify cartridge path
+
+After install, confirm the cartridge is on the site path: Business Manager → Administration → Sites → Manage Sites → *your site* → Settings. The CAP install job appends to the path automatically.
+
+### Test hooks
+
+Verify the hook is registered and firing:
+
+```javascript
+// In code, query the hook manager
+require('dw/system/HookMgr').hasHook('dw.order.calculateTax');
+```
+
+Trigger the hook (e.g., add to cart for tax calc) and watch logs:
+
+```bash
+b2c logs tail --filter customerror --filter customwarn --filter custominfo --search myapp
+```
+
+### Run unit tests
+
+If your cartridge ships with mocha tests (see `tax/avalara-tax/` for the pattern):
+
+```bash
+cd commerce-my-app-app-v1.0.0/cartridges/site_cartridges/int_myapp
 npm install
 npm test
-```
-
-**Test coverage:**
-```bash
-npm run test:coverage
 ```
 
 ---
 
 ## Testing Impex Files
 
-### 1. Validate XML Syntax
+**The CAP install job imports impex automatically.** During development, the recommended workflow is to package and install the CAP — this exercises exactly the same `sfcc-install-commerce-app` job a merchant runs, including the impex import, cartridge upload, and post-install task setup.
 
-Before importing, validate XML:
+### Recommended development loop
 
 ```bash
-# Validate services.xml
-xmllint --noout impex/install/services.xml
-
-# Validate all impex files
-find impex/ -name "*.xml" -exec xmllint --noout {} \;
-```
-
-**Using Claude Code:**
-```
+# 1. Validate impex syntax + structure first
 /validate-impex
+
+# 2. Validate against the SFCC XSDs (optional but catches most schema errors)
+xmllint --schema "$(b2c docs schema metadata --path)" \
+  impex/install/meta/system-objecttype-extensions.xml --noout
+xmllint --schema "$(b2c docs schema services --path)" impex/install/services.xml --noout
+
+# 3. Validate the CAP itself
+b2c cap validate ./commerce-my-app-app-v1.0.0
+
+# 4. Install — this imports impex, deploys cartridges, and registers the feature
+b2c cap install ./commerce-my-app-app-v1.0.0 --site-id RefArch
+
+# 5. Tail logs while the install runs
+b2c logs tail --filter customerror --filter error
 ```
 
-### 2. Import Service Configurations
+### Verify imported metadata
 
-**Via Business Manager:**
-1. Administration → Site Development → Import & Export
-2. Upload `impex/install/services.xml`
-3. Click Import and wait for completion
-4. Check for errors in import log
+| What | Where to look |
+|------|----------------|
+| Services | Administration → Operations → Services |
+| Site preferences | Merchant Tools → Site Preferences → Custom Preferences |
+| Custom object types | Administration → Site Development → System Object Types → Custom Object Types |
+| Cartridge path | Administration → Sites → Manage Sites → *site* → Settings |
+| Install job log on failure | `b2c job log sfcc-install-commerce-app --failed` |
 
-**Verify services created:**
-1. Administration → Operations → Services
-2. Find your service ID (e.g., `myapp.api`)
-3. Verify credential, profile, and service definition
+### Test the uninstall path
 
-### 3. Import Site Preferences
+`b2c cap uninstall` runs the uninstall impex from `impex/uninstall/`. Always test it on a sandbox before submitting:
 
-**Import metadata:**
-1. Upload `impex/install/meta/system-objecttype-extensions.xml`
-2. Import and check logs
+```bash
+b2c cap uninstall my-app --site-id RefArch
+b2c cap list --site-id RefArch  # confirm gone
+```
 
-**Import default values:**
-1. Replace `SITEID` with your actual site ID in `preferences.xml`
-2. Upload and import
+Then re-install to confirm the install/uninstall cycle is repeatable.
 
-**Verify preferences:**
-1. Merchant Tools → Site Preferences → Custom Preferences
-2. Find your app's preference group
-3. Verify all preferences appear
-4. Test different values
+> **Note:** Never test uninstall in production.
 
-### 4. Import Custom Object Types
+### Iterating on impex without re-installing the CAP
 
-**Import definitions:**
-1. Upload `impex/install/meta/custom-objecttype-definitions.xml`
-2. Import and check logs
+When you only need to push a metadata change and want to skip the full CAP install loop, use `b2c job import` to run `sfcc-site-archive-import` directly:
 
-**Verify custom objects:**
-1. Administration → Site Development → System Object Types
-2. Find your custom object type
-3. Verify attributes are defined
+```bash
+# Import a directory (zipped automatically) or an existing zip
+b2c job import ./impex/install
+b2c job import ./my-archive.zip
 
-**Test in code:**
+# Keep the archive on the instance after import
+b2c job import ./impex/install --keep-archive
+
+# Import an archive already on the instance
+b2c job import existing-archive.zip --remote
+```
+
+The CLI uploads to `Impex/src/instance/` and waits for the job. Errors are in `b2c job log sfcc-site-archive-import --failed`.
+
+> **Caveat:** This bypasses the CAP install pipeline (no cartridge path updates, no feature state registration, no post-install tasks). Use it for metadata-only iteration, then run a full `b2c cap install` before considering the change tested.
+
+### Importing manually from Business Manager
+
+Available as a fallback if the CLI isn't an option:
+
+1. Zip the `impex/install/` directory
+2. Administration → Site Development → Site Import & Export → upload the archive
+3. Select the archive and click **Import**
+4. Watch the import status; review the job log when it finishes (Administration → Operations → Jobs → `sfcc-site-archive-import`)
+5. To test uninstall, repeat with `impex/uninstall/`
+
+This path doesn't run the CAP install logic either — same caveat as `b2c job import`.
+
+### Custom object smoke test
+
+After install, verify a custom object type accepts data:
+
 ```javascript
 var CustomObjectMgr = require('dw/object/CustomObjectMgr');
+var Transaction = require('dw/system/Transaction');
 
-// Create test object
-var obj = CustomObjectMgr.createCustomObject('MyObjectType', 'test-key');
-obj.custom.myAttribute = 'test value';
+Transaction.wrap(function () {
+    var obj = CustomObjectMgr.createCustomObject('MyAppCache', 'test-key');
+    obj.custom.payload = 'test value';
+});
 
-// Retrieve
-var retrieved = CustomObjectMgr.getCustomObject('MyObjectType', 'test-key');
-Logger.debug('Retrieved: {0}', retrieved.custom.myAttribute);
-
-// Delete test object
-CustomObjectMgr.remove(obj);
+var retrieved = CustomObjectMgr.getCustomObject('MyAppCache', 'test-key');
+require('dw/system/Logger').debug('Retrieved: {0}', retrieved.custom.payload);
 ```
-
-### 5. Test Uninstall
-
-**IMPORTANT:** Only test in sandbox!
-
-1. Import `impex/uninstall/services.xml`
-2. Verify services are removed
-3. Re-import install files to restore
 
 ---
 
 ## Testing UI Components
 
-### 1. Local Development
+If your app includes Storefront Next extensions under `storefront-next/`:
 
-If your app includes Storefront Next extensions:
+### Local development
 
 ```bash
 cd storefront-next
@@ -226,426 +428,322 @@ npm install
 npm run dev
 ```
 
-**Test components in Storybook:**
+Component-level tests (Vitest) and Storybook stories run locally without a sandbox:
+
 ```bash
+npm run test
+npm run test:coverage
 npm run storybook
 ```
 
-### 2. Component Testing
+### Integration testing
 
-**Unit tests with Vitest:**
-```bash
-npm run test
-```
+Build the extensions, then deploy to your Storefront Next environment per the [Storefront Next documentation](https://dpkoal18ck1fm.cloudfront.net/docs/commerce/b2c-commerce/guide/index.html).
 
-**Test coverage:**
-```bash
-npm run test:coverage
-```
+Verify in the storefront:
 
-### 3. Integration Testing
+- Components render at the configured `target-config.json` targets
+- Data loads (check the network tab for SCAPI calls)
+- Styling, interactions, and responsive layouts work
+- No console errors
 
-Deploy to sandbox and test in context:
+### Browser coverage
 
-1. Build extensions:
-   ```bash
-   npm run build
-   ```
-
-2. Deploy to sandbox (consult SFCC documentation for deployment)
-
-3. Navigate to storefront and verify:
-   - Components render correctly
-   - Styling is correct
-   - Interactions work
-   - Data loads properly
-
-### 4. Browser Testing
-
-Test across browsers:
-- Chrome/Edge (latest)
-- Firefox (latest)
-- Safari (latest)
-- Mobile browsers (iOS Safari, Chrome Mobile)
-
-**Use DevTools:**
-- Check console for errors
-- Inspect network requests
-- Verify responsive design
-- Test accessibility
+Test on the latest Chrome/Edge, Firefox, Safari, and at least one mobile browser (iOS Safari or Chrome Mobile).
 
 ---
 
 ## Testing Services
 
-### 1. Configure Service Credentials
+### Configure credentials
 
-1. Administration → Operations → Services
-2. Select your service
-3. Configure credentials:
-   - Use sandbox/test API keys
-   - Set correct endpoint URL
-   - Test authentication
+After install, set sandbox/test credentials for each service:
 
-### 2. Test Service Calls
+1. Administration → Operations → Services → *your service* → Credentials
+2. Set the test endpoint URL and API key/secret
+3. Save
 
-**Via Service Definition:**
-1. In Business Manager → Operations → Services
-2. Click your service → Test tab
-3. Enter test request
-4. Click Test and verify response
+### Test a service call
 
-**Via Script:**
+**From Business Manager:** Operations → Services → *your service* → click the service definition → use the test request tool.
+
+**From a script:**
+
 ```javascript
 var MyService = require('*/cartridge/scripts/services/myService');
 
-// Test call
 var result = MyService.call({
     param1: 'test',
     param2: 'value'
 });
 
-if (result.success) {
-    Logger.info('Service call successful: {0}', JSON.stringify(result.data));
+if (result.status === 'OK') {
+    require('dw/system/Logger').info('Success: {0}', JSON.stringify(result.object));
 } else {
-    Logger.error('Service call failed: {0}', result.error);
+    require('dw/system/Logger').error('Failed: {0} {1}', result.error, result.errorMessage);
 }
 ```
 
-**Monitor service calls:**
-1. Administration → Operations → Services → Service Monitoring
-2. View call history, response times, errors
+### Monitor service calls
 
-### 3. Test Error Handling
+Administration → Operations → Services → Service Status / Service Monitoring shows call counts, error rates, and average response times.
 
-**Simulate failures:**
-- Invalid credentials (expect auth error)
-- Malformed requests (expect validation error)
-- Network timeout (expect timeout error)
-- Service unavailable (expect circuit breaker)
+### Verify error handling
 
-**Verify error handling:**
+Test each failure mode:
+
+- Invalid credentials → service returns auth error, app falls back gracefully
+- Malformed request → validation error logged, no exception bubbles to checkout
+- Timeout → app respects timeout configured on the service profile
+- Circuit open → after the configured failure threshold, calls short-circuit instead of blocking
+
 ```javascript
 try {
     var result = MyService.call(params);
-    if (!result.success) {
-        // Handle gracefully
-        Logger.error('Service error: {0}', result.error);
-        // Don't break checkout flow
+    if (result.status !== 'OK') {
+        Logger.error('Service error: {0}', result.errorMessage);
         return defaultBehavior();
     }
+    return result.object;
 } catch (e) {
-    Logger.error('Exception calling service: {0}', e.message);
+    Logger.error('Exception: {0}', e.message);
     return defaultBehavior();
 }
 ```
 
-### 4. Test Rate Limiting
+---
 
-**Trigger rate limits:**
-- Make rapid successive calls
-- Verify rate limiting kicks in
-- Check circuit breaker behavior
+## Inspecting Logs
 
-**Monitor in logs:**
-- Look for rate limit messages
-- Verify circuit opens/closes as expected
+Use `b2c logs` instead of downloading log files via WebDAV manually.
+
+### Tail logs in real time
+
+```bash
+# Default: error + customerror
+b2c logs tail
+
+# Custom logs only, filtered to your app
+b2c logs tail --filter custominfo --filter customwarn --filter customerror --search myapp
+
+# Only ERROR and FATAL entries
+b2c logs tail --level ERROR --level FATAL
+
+# NDJSON output (for piping to a parser)
+b2c logs tail --json
+```
+
+Press `Ctrl+C` to stop. The command tracks log rotation automatically.
+
+### One-shot retrieval
+
+```bash
+# Last 50 entries from error+customerror
+b2c logs get --count 50
+
+# Last hour of ERROR-level entries containing "PaymentProcessor"
+b2c logs get --since 1h --level ERROR --search PaymentProcessor
+
+# JSON for tooling
+b2c logs get --since 5m --json
+```
+
+Paths in log entries are auto-normalized to local cartridge paths so IDEs can click-to-open. Use `--no-normalize` to disable.
+
+### Job logs
+
+```bash
+# Most recent execution log
+b2c job log my-job
+
+# Most recent failed execution
+b2c job log my-job --failed
+
+# Specific execution
+b2c job log my-job abc123-def456
+```
+
+### Custom log levels
+
+Custom log files are produced by `Logger.debug/info/warn/error/fatal`. By default `customwarn`, `customerror`, and `customfatal` are always enabled; `custominfo` and `customdebug` must be enabled in Administration → Operations → Custom Log Settings.
 
 ---
 
 ## End-to-End Testing
 
-### 1. Installation Test
+### Fresh-install scenario
 
-**Fresh install:**
-1. Import all impex files
-2. Upload cartridges
-3. Configure site preferences
-4. Complete post-install tasks (from tasksList.json)
-5. Verify app works end-to-end
+1. Start from a clean sandbox site (uninstall any prior version: `b2c cap uninstall my-app -s RefArch`)
+2. `b2c cap install my-app-v1.0.0.zip --site-id RefArch`
+3. Run through the post-install tasks: `b2c cap tasks my-app --site-id RefArch`
+4. Smoke test the storefront flow your app extends (checkout, search, account, etc.)
 
-### 2. Checkout Flow (for checkout-related apps)
+### Checkout-flow apps (tax, payment, shipping)
 
-**Test complete checkout:**
-1. Add products to cart
-2. Proceed to checkout
-3. Verify your app's functionality (tax calc, shipping rates, payment, etc.)
-4. Complete order
-5. Check order in Business Manager
-6. Verify all hooks executed correctly
+Walk a complete order through the storefront and verify in Business Manager that:
 
-**Check logs:**
-- Custom logs for your app
-- System logs for errors
-- Service call logs
+- Hooks executed (custom logs show entry/exit)
+- Service calls succeeded (Service Monitoring)
+- Order totals are correct (tax, shipping, payment status)
+- No errors in `error` / `customerror` logs (`b2c logs get --since 10m --level ERROR`)
 
-### 3. Typical User Scenarios
+### Edge cases to cover
 
-**Create test scenarios:**
-```
-Scenario 1: Tax Calculation
-1. Customer in New York adds product to cart
-2. Tax calculated correctly for NY
-3. Customer changes address to California
-4. Tax recalculated for CA
-5. Order completes with correct tax
-
-Scenario 2: Shipping Rates
-1. Customer adds items to cart
-2. Shipping rates fetch successfully
-3. Customer selects shipping method
-4. Correct shipping cost applied
-5. Order completes with correct shipping
-```
-
-### 4. Edge Cases
-
-**Test edge cases:**
-- Empty cart
-- Single item vs. multiple items
-- High-value orders
+- Empty cart / single item / many items
+- High-value order
 - International shipping (if applicable)
-- Invalid addresses
-- Service timeouts
-- Network failures
+- Invalid address or invalid card
+- Service timeout (temporarily set a tiny timeout on the service profile)
+- Network failure (block the service URL via the platform firewall, or use an unreachable endpoint)
+
+### Uninstall scenario
+
+After end-to-end install testing:
+
+```bash
+b2c cap uninstall my-app --site-id RefArch
+b2c cap list --site-id RefArch  # confirm gone
+```
+
+Verify services, preferences, custom objects, and cartridge path entries are all removed.
 
 ---
 
 ## Performance Testing
 
-### 1. Response Time
+### Hook execution time
 
-**Measure hook execution time:**
 ```javascript
 var startTime = Date.now();
-
-// Your hook logic
-
-var duration = Date.now() - startTime;
-Logger.info('Hook execution time: {0}ms', duration);
+// ... hook logic ...
+require('dw/system/Logger').info('Hook execution time: {0}ms', Date.now() - startTime);
 ```
 
-**Target response times:**
-- Tax calculation: < 1000ms
-- Shipping rates: < 1500ms
-- Payment authorization: < 2000ms
-- Non-critical hooks: < 500ms
+Suggested targets:
 
-### 2. Service Call Performance
+| Hook | Target |
+|------|--------|
+| Tax calculation | < 1000 ms |
+| Shipping rates | < 1500 ms |
+| Payment authorization | < 2000 ms |
+| Non-critical hooks | < 500 ms |
 
-**Monitor in Business Manager:**
-- Administration → Operations → Services → Service Monitoring
-- Check average response times
-- Identify slow calls
+### Service performance
 
-**Optimize if needed:**
-- Add caching (custom objects)
-- Reduce payload size
-- Use appropriate timeouts
-- Implement circuit breakers
+Administration → Operations → Services → Service Monitoring shows averages and per-call timing. Optimize by:
 
-### 3. Caching Strategy
+- Caching responses in a custom object (use `/generate-custom-object-impex` for the type definition)
+- Reducing payload size
+- Tightening timeouts so failures fail fast
+- Confirming the circuit breaker thresholds on the service profile
 
-**Test cache behavior:**
+### Cache validation
+
 ```javascript
-// Cache hit
 var cached = getCachedData(key);
-if (cached) {
-    Logger.debug('Cache hit for key: {0}', key);
-    return cached;
-}
-
-// Cache miss - fetch and cache
+if (cached) { return cached; }
 var data = fetchFromService();
-cacheData(key, data, ttl);
+cacheData(key, data, ttlSeconds);
 return data;
 ```
 
-**Verify cache expiration:**
-- Check TTL behavior
-- Test cache invalidation
-- Monitor cache hit rate
+Verify TTL by waiting past the configured window and confirming a fresh service call. Verify cache invalidation paths if your app exposes one.
 
 ---
 
-## Validation Before Submission
+## Pre-Submission Checklist
 
-### 1. Automated Validation
+Before opening the PR (use `/submit-app` to drive this):
 
-**Using Claude Code:**
-```
-/validate-app
-/validate-impex
-```
+**Validation:**
+- [ ] `/validate-impex` passes
+- [ ] `b2c cap validate <path>` passes
+- [ ] `/validate-app` passes (covers manifest, SHA256, structure, security)
 
-**Manual validation:**
-```bash
-# XML syntax
-find impex/ -name "*.xml" -exec xmllint --noout {} \;
+**Files committed:**
+- [ ] `{domain}/{appName}/{appName}-v{version}.zip`
+- [ ] `{domain}/{appName}/manifest.json` (with matching SHA256)
+- [ ] `{domain}/{appName}/catalog.json` (new apps only)
+- [ ] **No** extracted directories (`commerce-{appName}-app-v{version}/`)
 
-# SHA256 hash
-shasum -a 256 my-app-v1.0.0.zip
-# Compare with manifest.json
+**ZIP contents:**
+- [ ] Single root folder `commerce-{appName}-app-v{version}/`
+- [ ] No junk files (`.DS_Store`, `__MACOSX`, hidden files)
+- [ ] `commerce-app.json`, `README.md`, `app-configuration/tasksList.json` present
+- [ ] No `pipeline/` directories or `*.ds` files
+- [ ] No `controllers/` under `cartridges/site_cartridges/*`
 
-# ZIP structure
-unzip -l my-app-v1.0.0.zip | head -20
-```
-
-### 2. Final Checklist
-
-Before submitting to registry:
-
-**Files:**
-- [ ] ZIP file follows naming convention
-- [ ] manifest.json has all required fields
-- [ ] SHA256 hash matches
-- [ ] catalog.json included (new apps only)
-- [ ] Only ZIP, manifest.json, catalog.json committed
-- [ ] No extracted directories committed
-
-**ZIP Contents:**
-- [ ] Single root folder with correct name
-- [ ] No junk files (.DS_Store, __MACOSX, etc.)
-- [ ] commerce-app.json present and valid
-- [ ] README.md included
-- [ ] All referenced files exist
-
-**Testing:**
-- [ ] Installed in sandbox successfully
-- [ ] All impex files import without errors
-- [ ] Services authenticate and respond
-- [ ] Hooks execute correctly
-- [ ] UI components render properly
-- [ ] No errors in logs during testing
-- [ ] Performance is acceptable
-- [ ] Edge cases handled gracefully
+**Sandbox testing:**
+- [ ] CAP installs cleanly via `b2c cap install`
+- [ ] Post-install tasks (`b2c cap tasks`) make sense and have working BM links
+- [ ] App functions correctly in storefront
+- [ ] No errors in `b2c logs get --since 1h --level ERROR`
+- [ ] `b2c cap uninstall` removes everything
 
 **Security:**
-- [ ] No hardcoded production credentials
-- [ ] No sensitive data in code or impex
-- [ ] Input validation implemented
-- [ ] Error messages don't leak information
+- [ ] No hardcoded production credentials anywhere
+- [ ] Sensitive site preferences use `<password>` type
+- [ ] Error messages don't leak internal details
+- [ ] Input validation at trust boundaries
 
 **Documentation:**
-- [ ] README.md is complete and accurate
-- [ ] Installation steps are clear
-- [ ] Configuration documented
-- [ ] Troubleshooting section included
-
-### 3. Get Feedback
-
-**Before final submission:**
-- Have a colleague review
-- Test on a fresh sandbox
-- Verify all post-install tasks are clear
-- Check that merchants can configure successfully
+- [ ] `README.md` covers installation, configuration, and troubleshooting
+- [ ] `app-configuration/tasksList.json` lists every required post-install task with a working BM link
 
 ---
 
 ## Common Testing Issues
 
-### Issue: Cartridge Upload Fails
-**Solutions:**
-- Check file permissions
-- Verify cartridge name in manifest
-- Check for syntax errors in code
-- Ensure cartridge path is correct
+### `cap install` fails with structural errors
+Run `b2c cap validate` to see the specific rule violation. Most commonly: missing `commerce-app.json` field, invalid semver, missing `tasksList.json`, or pipeline files left in cartridges.
 
-### Issue: Impex Import Errors
-**Solutions:**
-- Validate XML syntax with xmllint
-- Check for duplicate IDs
-- Verify namespaces are correct
-- Replace SITEID with actual site ID
+### Impex import errors
+- Run `/validate-impex` first
+- Check for unescaped `&` or `<` in XML (`&amp;` / `&lt;`)
+- Confirm namespaces match the SFCC schema (e.g., `services/2015-07-01`)
+- Replace `SITEID` with the actual site ID only via `preferences.xml` substitution — never commit a real site ID
+- Get the failing job's log: `b2c job log sfcc-site-archive-import --failed`
 
-### Issue: Service Call Fails
-**Solutions:**
-- Verify credentials are correct
-- Check endpoint URL
-- Test with Postman first
-- Check service logs for details
-- Verify network access from SFCC
+### Service call fails
+- Verify credentials are sandbox/test values, not production
+- Confirm the endpoint is reachable from SFCC (check Service Monitoring for the actual error)
+- Run `b2c logs get --search myService.api --since 10m`
+- Check the circuit-breaker state in Service Monitoring — a tripped circuit keeps the service offline until reset
 
-### Issue: Hook Not Executing
-**Solutions:**
-- Verify hooks.json is correct
-- Check hook is registered: `require('dw/system/HookMgr').hasHook('hook.name')`
-- Verify cartridge is in path
-- Check for syntax errors in hook script
-- Add debug logging
+### Hook not firing
+- Confirm the cartridge is on the site path (Manage Sites → Settings)
+- Verify `package.json` `"hooks"` (or `hooks.json`) is correct and the script paths resolve
+- `require('dw/system/HookMgr').hasHook('your.hook.name')` returns `true`?
+- Add `Logger.info` at the top of the hook and tail logs
 
-### Issue: UI Component Not Rendering
-**Solutions:**
+### UI component not rendering
 - Check browser console for errors
-- Verify component is registered in target-config.json
-- Check that extension is deployed
-- Verify data is loading correctly
-- Test in isolation (Storybook)
+- Confirm the component is registered in `target-config.json` and the target ID matches a real Storefront Next target
+- Confirm the extension is deployed to the storefront environment
+- Test the component in isolation (Storybook) to rule out target/data issues
+
+### SHA256 mismatch on PR
+The hash in `manifest.json` doesn't match the ZIP. Run `/package-app` (or recompute manually with `shasum -a 256`) and commit the updated manifest.
 
 ---
 
 ## Best Practices
 
-### 1. Test Early and Often
-- Test as you build, not just at the end
-- Test each component independently
-- Integration test after components work individually
-
-### 2. Use Separate Sandbox
-- Don't test in production (obviously!)
-- Use dedicated test sandbox if available
-- Keep test data realistic but not production data
-
-### 3. Automate Testing
-- Write unit tests for business logic
-- Use CI/CD for validation
-- Automate impex validation
-
-### 4. Document Test Results
-- Keep notes on what you tested
-- Document any workarounds needed
-- Note performance metrics
-
-### 5. Test Uninstall
-- Verify cleanup works correctly
-- Test in sandbox before providing to merchants
-- Ensure no orphaned data
+- **Test as you build.** Validate impex on every change with `/validate-impex`. Tail logs in a side terminal during development.
+- **Use a dedicated sandbox.** Don't share with someone else's in-progress work, and never test on production.
+- **Test the uninstall path.** A clean uninstall is a release requirement, not an afterthought.
+- **Automate validation.** Wire `b2c cap validate` and the impex validator into CI for app repos that live outside this registry.
+- **Keep credentials out of the repo.** Use `.envrc`, direnv, or your shell profile for `SFCC_*` variables — never commit them.
 
 ---
 
 ## Getting Help
 
-If you encounter testing issues:
-
-1. **Check logs:**
-   - Custom logs in Business Manager
-   - System logs
-   - Service call logs
-   - Browser console
-
-2. **Review documentation:**
+1. **Logs first:** `b2c logs tail`, `b2c logs get --since 10m --level ERROR`, `b2c job log <id> --failed`
+2. **Documentation:**
+   - [B2C Developer Tooling docs](https://salesforcecommercecloud.github.io/b2c-developer-tooling/)
    - [SFCC Documentation](https://developer.salesforce.com/docs/commerce/b2c-commerce)
    - [CONTRIBUTING.md](../CONTRIBUTING.md)
-   - [README.md](../README.md)
-
-3. **Ask for help:**
-   - GitHub Discussions
-   - Salesforce Developer Forums
-   - Internal team if part of organization
-
-4. **Use validation skills:**
-   - `/validate-app`
-   - `/validate-impex`
-
----
-
-## Summary
-
-Good testing ensures:
-- ✅ App works correctly in all scenarios
-- ✅ No errors during installation
-- ✅ Merchant can configure successfully
-- ✅ Performance is acceptable
-- ✅ Code is production-ready
-
-Take time to test thoroughly - it saves time in code review and prevents issues for merchants!
+   - [AGENTS.md](../AGENTS.md) — guidance for AI assistants in this repo
+3. **Validation skills:** `/validate-app`, `/validate-impex`
+4. **Reference app:** `tax/avalara-tax/` — a working CAP with cartridges, hooks, impex, and unit tests

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,21 +49,18 @@ Install per the [extension installation docs](https://salesforcecommercecloud.gi
 
 ### `b2c` CLI
 
-The [`b2c` CLI](https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/) is the primary tool for testing apps against a sandbox. Install it once and authenticate via environment variables.
+The [`b2c` CLI](https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/) is the primary tool for testing apps against a sandbox. Install it once and configure your sandbox connection.
 
 ```bash
 # Install
 npm install -g @salesforce/b2c-cli
 # or use without install: npx @salesforce/b2c-cli ...
 
-# Configure once per shell (or use a .envrc / direnv)
-export SFCC_SERVER=my-sandbox.demandware.net
-export SFCC_USERNAME=my-bm-user
-export SFCC_PASSWORD=my-webdav-access-key
-export SFCC_CLIENT_ID=my-client
-export SFCC_CLIENT_SECRET=my-secret
-export SFCC_CODE_VERSION=version1
+# Configure interactively — writes a dw.json
+b2c setup instance
 ```
+
+The idiomatic configuration is a `dw.json` file at the project root (or any parent directory). The same file is picked up by the [B2C DX VS Code extension](https://salesforcecommercecloud.github.io/b2c-developer-tooling/vscode-extension/), so configuring once works for both. CLI flags and `SFCC_*` environment variables are also supported. See the [Configuration guide](https://salesforcecommercecloud.github.io/b2c-developer-tooling/guide/configuration) for the full schema, multi-instance setups, and the precedence rules.
 
 Key commands referenced in this guide:
 


### PR DESCRIPTION
## Summary

Rewrites `docs/testing.md` around the actual recommended workflow:

- **CAP install is the primary path.** `b2c cap validate` → `b2c cap install` exercises the same `sfcc-install-commerce-app` job a merchant runs (impex import, cartridge deploy, feature registration, post-install tasks). Iterating against this loop catches the most issues end-to-end.
- **Skills surfaced.** `/scaffold-app`, `/generate-*-impex`, `/validate-impex`, `/validate-app`, `/package-app`, `/submit-app` are introduced in a dedicated Tooling section with guidance on when each fits.
- **`b2c` CLI introduced** with env var setup and a command reference table covering `cap`, `code`, `job`, `logs`, and `sandbox`. Links into the b2c-developer-tooling docs.
- **Impex iteration paths repositioned.** `b2c job import` is documented as a metadata-only shortcut with an explicit caveat that it bypasses cartridge-path updates and feature-state registration; manual Business Manager import is documented as a fallback with the same caveat.
- **XSD validation via the CLI** added: `xmllint --schema "$(b2c docs schema metadata --path)" ...` for metadata, services, and preferences. `b2c docs schema --list` for discovery.
- **Logs section** rewritten around `b2c logs tail` / `b2c logs get` with real flags (`--filter`, `--level`, `--search`, `--since`, `--json`) and `b2c job log --failed` for job log retrieval.
- **Inaccuracies corrected:** removed UX Studio / Prophet / dwupload as primary cartridge tools, fixed the service result API (`result.status === 'OK'` / `result.object`, not the made-up `success`/`data`), wrapped the custom object example in a `Transaction.wrap`, and updated the pre-submission checklist to match the rules in `AGENTS.md` (single root folder, no pipelines, no controllers under `site_cartridges/`, `tasksList.json` required).

## Test plan

- [ ] Render `docs/testing.md` on GitHub and confirm formatting (tables, code blocks, anchor links in TOC)
- [ ] Spot-check that every `b2c` command shown matches the [CLI docs](https://salesforcecommercecloud.github.io/b2c-developer-tooling/cli/)
- [ ] Confirm skill names and descriptions match `.claude/skills/` and `AGENTS.md`
- [ ] Verify the recommended dev loop end-to-end against a sandbox using a real app (e.g. `tax/avalara-tax/`)