### PR TITLE
@W-22477103: Enhance security scanner per CAP threat model

### DIFF
--- a/.claude/skills/package-app/references/security-scan.md
+++ b/.claude/skills/package-app/references/security-scan.md
@@ -8,24 +8,9 @@ Run before packaging any app to catch security issues early.
 bash .github/scripts/security-scan.sh <domain>/<appName>/commerce-<appName>-app-v<version>/
 ```
 
-## Blocking findings (exit code 1)
+## Rule reference
 
-**Must fix before packaging:**
-- Dynamic code evaluation constructs — code injection sinks
-- Hardcoded secrets or credentials (API keys, AWS keys, GitHub PATs, Slack tokens, private keys)
-- Hook scripts referenced in hooks.json that don't exist on disk
-- Missing uninstall/services.xml or missing mode="delete" attributes
-- Unsafe HTML manipulation — XSS risk
-
-## Warning findings (review recommended)
-
-**Should fix but non-blocking:**
-- Console logging in cartridge code — use dw.system.Logger instead
-- HTTPClient without explicit timeout configuration
-- Service profile XML missing timeout-millis element
-- Hook scripts without try/catch error handling
-- Non-cryptographic random number generation
-- Inline Authorization headers instead of service framework
+See [security-rules.md](../../shared/security-rules.md) for the complete list of blocking and warning checks.
 
 ## Response to findings
 

--- a/.claude/skills/shared/security-rules.md
+++ b/.claude/skills/shared/security-rules.md
@@ -1,0 +1,37 @@
+# Security Scan Rules
+
+Canonical list of all checks performed by `.github/scripts/security-scan.sh`.
+
+## Blocking findings (21 checks — exit code 1)
+
+Must fix before packaging or submission:
+
+- S1: Dynamic code evaluation constructs — code injection sinks
+- S2: Dynamic module loading with concatenation
+- S3: Unsafe innerHTML assignment — XSS risk
+- S4: Hardcoded secrets (API keys, AWS keys, GitHub PATs, Slack tokens, private keys)
+- S5: Hardcoded credentials in impex XML
+- S7: Inline Authorization headers — must use service framework
+- S8: Additional DOM sinks — outerHTML assignment, document.write, insertAdjacentHTML
+- S9: ISML `<isprint>` with `encoding="off"` — template injection
+- S10: Secret files in package (.env, .key, .pem, .p12, .pfx, .jks)
+- S11: Direct HTTPClient usage — must use service framework
+- S13: setTimeout/setInterval in hook scripts — blocking calls
+- S14: Unbounded loops (while(true)/for(;;)) without break/return
+- S15: Service profiles missing rate-limit-enabled AND circuit-breaker-enabled
+- P1: Service profile XML missing timeout-millis
+- Q1: Hook scripts referenced in hooks.json that don't exist
+- Q2: Hook scripts missing expected function exports
+- Q3: Missing error handling (try/catch) in hook scripts
+- Q4: Missing uninstall/services.xml or missing mode="delete" (including service ID mismatches)
+- Q5: Hardcoded site-id instead of SITEID placeholder
+- Q6: Absolute file paths in code
+- Q7: Console logging in cartridge code — use dw.system.Logger
+
+## Warning findings (3 checks — review recommended)
+
+Should fix but non-blocking:
+
+- S6: Non-cryptographic random number generation (Math.random)
+- S12: PII field names in Logger calls (may be false positive — requires context)
+- S16: Session object access in hook scripts (dw.system.Session, session.privacy)

--- a/.claude/skills/validate-app/references/security-scan.md
+++ b/.claude/skills/validate-app/references/security-scan.md
@@ -2,32 +2,43 @@
 
 Comprehensive security validation for commerce apps before PR submission.
 
-## Automated security scan
+## Two-phase security validation
+
+### Phase 1: Automated scan script
 
 ```bash
 bash .github/scripts/security-scan.sh commerce-<appName>-app-v<version>/
 ```
 
-**Blocking issues (must fix):**
-- Dynamic code evaluation constructs — code injection sinks
-- Dynamic module loading with concatenation
-- Unsafe HTML manipulation — XSS risk
-- Hardcoded secrets (API keys, AWS keys, GitHub PATs, Slack tokens, private keys)
-- Hardcoded credentials in impex XML
-- Hook scripts referenced in hooks.json that don't exist
-- Missing uninstall/services.xml or missing mode="delete"
+See [security-rules.md](../../shared/security-rules.md) for the complete list of blocking and warning checks.
 
-**Warnings (should review):**
-- Non-cryptographic random number generation
-- Inline Authorization headers instead of service framework
-- Console logging in cartridge code — use dw.system.Logger
-- HTTPClient without explicit timeout
-- Service profile XML missing timeout-millis
-- Hook scripts without try/catch error handling
-- Hook exports not matching expected function names
-- Hardcoded site-id instead of SITEID placeholder
-- Absolute file paths in code
-- Install/uninstall service ID mismatches
+### Phase 2: AI-powered semantic review
+
+After the script runs, perform semantic analysis:
+
+**Data exfiltration patterns:**
+- Review hook scripts and service calls for unauthorized data collection
+- Does the app send basket, customer, or order data to endpoints unrelated to its declared domain?
+- Example violation: Tax app sending customer emails to external analytics service
+
+**Permission scope creep:**
+- Does the app access Script API objects or customer data beyond its stated purpose?
+- Example violation: Shipping app reading dw.customer.Profile payment instruments
+
+**Business logic vulnerabilities:**
+- Could hook implementations be manipulated? (negative tax values, price overrides)
+- Race conditions in shared state access?
+- Improper input validation that could affect calculations?
+
+**Service call patterns:**
+- Are external API calls batched efficiently, or one call per line item?
+- Are service responses validated before use?
+- Is retry logic present that could cause duplicate side effects (double-charging)?
+
+**Impex safety:**
+- Do install impex files create overly broad permissions?
+- Do custom object definitions expose sensitive data without access controls?
+- Are retention policies appropriate for data sensitivity?
 
 ## Reporting findings
 
@@ -37,7 +48,7 @@ bash .github/scripts/security-scan.sh commerce-<appName>-app-v<version>/
 - Explain the security risk
 - Recommend specific fixes
 
-**Warning findings:**
+**Warnings from semantic review:**
 - Include in validation report with clear explanations
 - Mark as warnings (non-blocking)
 - Explain potential risks and recommended improvements

--- a/.github/scripts/security-scan.sh
+++ b/.github/scripts/security-scan.sh
@@ -44,6 +44,12 @@ warn() {
   WARNINGS=$((WARNINGS + 1))
 }
 
+# Filter out lines that are comments. Works with grep -n output (N:// or N:  //)
+# and block comments (N: * or N:/*). Strips the line-number prefix before checking.
+strip_comments() {
+  grep -vE '^[0-9]+:\s*//' | grep -vE '^[0-9]+:\s*\*' | grep -vE '^[0-9]+:\s*/\*'
+}
+
 # Collect JS/DS files (cartridge server-side scripts + storefront-next TS)
 # Using while-read for macOS bash 3 compatibility (no mapfile)
 JS_FILES=()
@@ -56,13 +62,39 @@ XML_FILES=()
 while IFS= read -r f; do XML_FILES+=("$f"); done < <(find "$CAP_ROOT" -type f -name '*.xml' 2>/dev/null || true)
 JSON_FILES=()
 while IFS= read -r f; do JSON_FILES+=("$f"); done < <(find "$CAP_ROOT" -type f -name '*.json' 2>/dev/null || true)
+ISML_FILES=()
+while IFS= read -r f; do ISML_FILES+=("$f"); done < <(find "$CAP_ROOT" -type f -name '*.isml' 2>/dev/null || true)
+
+# Read app domain from commerce-app.json (used by S15 for recommended values)
+APP_DOMAIN=""
+COMMERCE_APP_JSON="$(find "$CAP_ROOT" -maxdepth 2 -name 'commerce-app.json' -print -quit 2>/dev/null || true)"
+if [[ -n "$COMMERCE_APP_JSON" && -f "$COMMERCE_APP_JSON" ]]; then
+  APP_DOMAIN="$(jq -r '.domain // empty' "$COMMERCE_APP_JSON" 2>/dev/null || true)"
+fi
+
+# Collect hook script paths for hook-scoped rules (S13, S16)
+HOOK_SCRIPT_FILES=()
+HOOKS_FILES=()
+while IFS= read -r f; do HOOKS_FILES+=("$f"); done < <(find "$CAP_ROOT" -type f -name 'hooks.json' 2>/dev/null || true)
+for hooks_file in ${HOOKS_FILES[@]+"${HOOKS_FILES[@]}"}; do
+  [[ -z "$hooks_file" ]] && continue
+  hooks_dir="$(dirname "$hooks_file")"
+  while IFS= read -r script_path; do
+    [[ -z "$script_path" || "$script_path" == "null" ]] && continue
+    rel="${script_path#./}"
+    target="$hooks_dir/$rel"
+    [[ -f "$target" ]] && HOOK_SCRIPT_FILES+=("$target")
+  done < <(jq -r '.hooks[]?.script // empty' "$hooks_file" 2>/dev/null)
+done
 
 echo "=== Security & Quality Scan ==="
 echo "CAP root: $CAP_ROOT"
 echo "JS/DS files: ${#JS_FILES[@]}"
 echo "TS/TSX files: ${#TS_FILES[@]}"
 echo "XML files: ${#XML_FILES[@]}"
+echo "ISML files: ${#ISML_FILES[@]}"
 echo "Code files: ${#ALL_CODE_FILES[@]}"
+echo "App domain: ${APP_DOMAIN:-<not detected>}"
 echo ""
 
 # ============================= SECURITY =====================================
@@ -74,20 +106,19 @@ for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
   while IFS= read -r line; do
     block "$f" "eval() detected — code injection risk: $line"
-  done < <(grep -nE '\beval\s*\(' "$f" 2>/dev/null | grep -v '^\s*//' | grep -v '^\s*\*' | head -5)
+  done < <(grep -nE '\beval\s*\(' "$f" 2>/dev/null | strip_comments | head -5)
 
   while IFS= read -r line; do
     block "$f" "new Function() detected — code injection risk: $line"
-  done < <(grep -nE '\bnew\s+Function\s*\(' "$f" 2>/dev/null | grep -v '^\s*//' | grep -v '^\s*\*' | head -5)
+  done < <(grep -nE '\bnew\s+Function\s*\(' "$f" 2>/dev/null | strip_comments | head -5)
 done
 
 # S2: Dynamic require() — non-literal string argument (BLOCK)
 for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
-  # Match require( but not require('...' or require("...
   while IFS= read -r line; do
     block "$f" "Dynamic require() with concatenation detected: $line"
-  done < <(grep -nE 'require\s*\([^)]*\+' "$f" 2>/dev/null | grep -v '^\s*//' | head -5)
+  done < <(grep -nE 'require\s*\([^)]*\+' "$f" 2>/dev/null | strip_comments | head -5)
 done
 
 # S3: innerHTML assignment (BLOCK)
@@ -95,7 +126,7 @@ for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
   while IFS= read -r line; do
     block "$f" "innerHTML assignment detected — XSS risk: $line"
-  done < <(grep -nE '\.innerHTML\s*=' "$f" 2>/dev/null | grep -v '^\s*//' | head -5)
+  done < <(grep -nE '\.innerHTML\s*=' "$f" 2>/dev/null | strip_comments | head -5)
 done
 
 # S4: Hardcoded secret patterns (BLOCK)
@@ -113,14 +144,13 @@ for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
   for pattern in "${SECRET_PATTERNS[@]}"; do
     while IFS= read -r line; do
       block "$f" "Possible hardcoded secret detected: $line"
-    done < <(grep -nE "$pattern" "$f" 2>/dev/null | grep -v '^\s*//' | head -3)
+    done < <(grep -nE -- "$pattern" "$f" 2>/dev/null | strip_comments | head -3)
   done
 done
 
 # S5: Hardcoded secrets in XML (impex credentials) (BLOCK)
 for f in ${XML_FILES[@]+"${XML_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
-  # Check <password> or <user-id> values that look like real credentials (length > 20, not a placeholder)
   while IFS= read -r line; do
     block "$f" "Possible hardcoded credential in XML: $line"
   done < <(grep -nE '<password>[^<]{20,}</password>' "$f" 2>/dev/null | grep -vi 'YOUR_\|PLACEHOLDER\|CHANGEME\|TODO\|xxx' | head -3)
@@ -131,15 +161,127 @@ for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
   while IFS= read -r line; do
     warn "$f" "Math.random() detected — not cryptographically secure: $line"
-  done < <(grep -nE 'Math\.random\s*\(' "$f" 2>/dev/null | grep -v '^\s*//' | head -3)
+  done < <(grep -nE 'Math\.random\s*\(' "$f" 2>/dev/null | strip_comments | head -3)
 done
 
-# S7: Credentials outside service framework (WARN)
+# S7: Credentials outside service framework (BLOCK)
 for f in ${JS_FILES[@]+"${JS_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
   while IFS= read -r line; do
-    warn "$f" "Inline Authorization header — use service framework instead: $line"
+    block "$f" "Inline Authorization header — use service framework instead: $line"
   done < <(grep -nE 'setRequestHeader\s*\(\s*['\''"]Authorization' "$f" 2>/dev/null | head -3)
+done
+
+# S8: Additional DOM sinks — outerHTML, document.write, insertAdjacentHTML (BLOCK)
+for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    block "$f" "outerHTML assignment detected — XSS risk: $line"
+  done < <(grep -nE '\.outerHTML\s*=' "$f" 2>/dev/null | strip_comments | head -5)
+
+  while IFS= read -r line; do
+    block "$f" "document.write() detected — XSS risk: $line"
+  done < <(grep -nE 'document\[?['\''"]?write(ln)?['\''"]?\]?\s*\(' "$f" 2>/dev/null | strip_comments | head -5)
+
+  while IFS= read -r line; do
+    block "$f" "insertAdjacentHTML() detected — XSS risk: $line"
+  done < <(grep -nE '\.insertAdjacentHTML\s*\(' "$f" 2>/dev/null | strip_comments | head -5)
+done
+
+# S9: ISML template injection — encoding="off" (BLOCK)
+for f in ${ISML_FILES[@]+"${ISML_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    block "$f" "ISML isprint with encoding=\"off\" — XSS risk: $line"
+  done < <(grep -nE '<isprint[^>]+encoding\s*=\s*"off"' "$f" 2>/dev/null | head -5)
+done
+
+# S10: Secret files in package (BLOCK)
+while IFS= read -r f; do
+  block "$f" "Secret file detected in package — must not ship key/env files"
+done < <(find "$CAP_ROOT" -type f \( -name '*.env' -o -name '.env' -o -name '*.key' -o -name '*.pem' -o -name '*.p12' -o -name '*.pfx' -o -name '*.jks' \) 2>/dev/null || true)
+
+# S11: Direct HTTPClient usage — must use service framework (BLOCK)
+for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    block "$f" "Direct HTTPClient usage — must use service framework: $line"
+  done < <(grep -nE '\bHTTPClient\b' "$f" 2>/dev/null | strip_comments | head -5)
+done
+
+# S12: Sensitive data in logs — PII field names in Logger calls (WARN)
+for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    warn "$f" "Possible PII in log statement: $line"
+  done < <(grep -nE '(Logger|log)\.(info|debug|error|warn|trace)\s*\(.*\b(creditCard|cardNumber|cvv|password|passwd|secret|ssn|socialSecurity|taxId|bankAccount)\b' "$f" 2>/dev/null | strip_comments | head -5)
+done
+
+# S13: Blocking/sleep in hook scripts — setTimeout/setInterval (BLOCK)
+for f in ${HOOK_SCRIPT_FILES[@]+"${HOOK_SCRIPT_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    block "$f" "setTimeout/setInterval in hook script — blocking call: $line"
+  done < <(grep -nE '\b(setTimeout|setInterval)\s*\(' "$f" 2>/dev/null | strip_comments | head -5)
+done
+
+# S14: Unbounded loops — while(true)/for(;;) without break/return within 20 lines (BLOCK)
+for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r match; do
+    line_num="${match%%:*}"
+    end_line=$((line_num + 20))
+    if ! sed -n "${line_num},${end_line}p" "$f" 2>/dev/null | grep -qE '\b(break|return)\b'; then
+      block "$f" "Unbounded loop without break/return within 20 lines (line $line_num)"
+    fi
+  done < <(grep -nE 'while\s*\(\s*true\s*\)|for\s*\(\s*;\s*;\s*\)' "$f" 2>/dev/null | strip_comments)
+done
+
+# S15: Missing rate limiting and circuit breaker on service profiles (BLOCK)
+# Applies to ALL apps with service profiles
+S15_IDEAL_TAX="    <timeout-millis>5000</timeout-millis>\n    <rate-limit-enabled>true</rate-limit-enabled>\n    <rate-limit-calls>100</rate-limit-calls>\n    <rate-limit-millis>1000</rate-limit-millis>\n    <cb-enabled>true</cb-enabled>\n    <cb-calls>3</cb-calls>\n    <cb-millis>10000</cb-millis>"
+S15_IDEAL_PAYMENT="    <timeout-millis>10000</timeout-millis>\n    <rate-limit-enabled>true</rate-limit-enabled>\n    <rate-limit-calls>50</rate-limit-calls>\n    <rate-limit-millis>1000</rate-limit-millis>\n    <cb-enabled>true</cb-enabled>\n    <cb-calls>3</cb-calls>\n    <cb-millis>10000</cb-millis>"
+S15_IDEAL_FRAUD="    <timeout-millis>5000</timeout-millis>\n    <rate-limit-enabled>true</rate-limit-enabled>\n    <rate-limit-calls>100</rate-limit-calls>\n    <rate-limit-millis>1000</rate-limit-millis>\n    <cb-enabled>true</cb-enabled>\n    <cb-calls>3</cb-calls>\n    <cb-millis>10000</cb-millis>"
+S15_IDEAL_SHIPPING="    <timeout-millis>5000</timeout-millis>\n    <rate-limit-enabled>true</rate-limit-enabled>\n    <rate-limit-calls>100</rate-limit-calls>\n    <rate-limit-millis>1000</rate-limit-millis>\n    <cb-enabled>true</cb-enabled>\n    <cb-calls>5</cb-calls>\n    <cb-millis>10000</cb-millis>"
+S15_IDEAL_DEFAULT="    <timeout-millis>10000</timeout-millis>\n    <rate-limit-enabled>true</rate-limit-enabled>\n    <rate-limit-calls>100</rate-limit-calls>\n    <rate-limit-millis>1000</rate-limit-millis>\n    <cb-enabled>true</cb-enabled>\n    <cb-calls>5</cb-calls>\n    <cb-millis>10000</cb-millis>"
+
+s15_get_ideal() {
+  case "$APP_DOMAIN" in
+    tax) printf '%b' "$S15_IDEAL_TAX" ;;
+    payment) printf '%b' "$S15_IDEAL_PAYMENT" ;;
+    fraud) printf '%b' "$S15_IDEAL_FRAUD" ;;
+    shipping) printf '%b' "$S15_IDEAL_SHIPPING" ;;
+    *) printf '%b' "$S15_IDEAL_DEFAULT" ;;
+  esac
+}
+
+for f in ${XML_FILES[@]+"${XML_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  case "$f" in */uninstall/*) continue ;; esac
+  if grep -qE '<service-profile' "$f" 2>/dev/null; then
+    has_rate_limit=false
+    has_circuit_breaker=false
+    if grep -qE '<rate-limit-enabled>true</rate-limit-enabled>' "$f" 2>/dev/null; then
+      has_rate_limit=true
+    fi
+    if grep -qE '<circuit-breaker-enabled>true</circuit-breaker-enabled>|<cb-enabled>true</cb-enabled>' "$f" 2>/dev/null; then
+      has_circuit_breaker=true
+    fi
+    if [[ "$has_rate_limit" == "false" || "$has_circuit_breaker" == "false" ]]; then
+      ideal="$(s15_get_ideal)"
+      domain_label="${APP_DOMAIN:-All others}"
+      block "$f" "Service profile missing rate limiting and/or circuit breaker. Recommended config for ${domain_label} apps:
+${ideal}"
+    fi
+  fi
+done
+
+# S16: Session object access in hook scripts (WARN)
+for f in ${HOOK_SCRIPT_FILES[@]+"${HOOK_SCRIPT_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    warn "$f" "Session access in hook script — review for data leakage: $line"
+  done < <(grep -nE 'dw\.system\.Session|require.*dw/system/Session|session\.(privacy|custom|forms)' "$f" 2>/dev/null | head -5)
 done
 
 echo ""
@@ -148,32 +290,13 @@ echo ""
 
 echo "--- Performance Checks ---"
 
-# P1: console.log in production cartridge code (WARN)
-for f in ${JS_FILES[@]+"${JS_FILES[@]}"}; do
-  [[ -z "$f" ]] && continue
-  while IFS= read -r line; do
-    warn "$f" "console.log/debug statement in cartridge code — use dw.system.Logger: $line"
-  done < <(grep -nE 'console\.(log|debug|info|warn|error)\s*\(' "$f" 2>/dev/null | grep -v '^\s*//' | head -5)
-done
-
-# P2: Missing timeout on HTTPClient calls (WARN)
-for f in ${JS_FILES[@]+"${JS_FILES[@]}"}; do
-  [[ -z "$f" ]] && continue
-  if grep -lE 'HTTPClient' "$f" 2>/dev/null >/dev/null; then
-    if ! grep -qE 'setTimeout\|setConnectionTimeout\|\.setTimeout' "$f" 2>/dev/null; then
-      warn "$f" "HTTPClient used without explicit timeout configuration"
-    fi
-  fi
-done
-
-# P3: Missing timeout in service profile XML (WARN)
-# Only check install XMLs — uninstall uses mode="delete" and won't define profiles
+# P1: Missing timeout in service profile XML (BLOCK)
 for f in ${XML_FILES[@]+"${XML_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
   case "$f" in */uninstall/*) continue ;; esac
   if grep -qE '<service-profile' "$f" 2>/dev/null; then
     if ! grep -qE '<timeout-millis>' "$f" 2>/dev/null; then
-      warn "$f" "Service profile missing <timeout-millis> — requests may hang indefinitely"
+      block "$f" "Service profile missing <timeout-millis> — requests may hang indefinitely"
     fi
   fi
 done
@@ -185,8 +308,6 @@ echo ""
 echo "--- Quality Checks ---"
 
 # Q1: Hook scripts referenced in hooks.json must exist (BLOCK)
-HOOKS_FILES=()
-while IFS= read -r f; do HOOKS_FILES+=("$f"); done < <(find "$CAP_ROOT" -type f -name 'hooks.json' 2>/dev/null || true)
 for hooks_file in ${HOOKS_FILES[@]+"${HOOKS_FILES[@]}"}; do
   [[ -z "$hooks_file" ]] && continue
   hooks_dir="$(dirname "$hooks_file")"
@@ -201,14 +322,13 @@ for hooks_file in ${HOOKS_FILES[@]+"${HOOKS_FILES[@]}"}; do
   done < <(jq -r '.hooks[]?.script // empty' "$hooks_file" 2>/dev/null)
 done
 
-# Q2: Hook functions must be exported (WARN)
+# Q2: Hook functions must be exported (BLOCK)
 for hooks_file in ${HOOKS_FILES[@]+"${HOOKS_FILES[@]}"}; do
   [[ -z "$hooks_file" ]] && continue
   hooks_dir="$(dirname "$hooks_file")"
 
   while IFS= read -r entry; do
     script="$(jq -r '.script // empty' <<< "$entry" 2>/dev/null)"
-    # Extract function name from hook name (last segment after .)
     hook_name="$(jq -r '.name // empty' <<< "$entry" 2>/dev/null)"
     [[ -z "$script" || -z "$hook_name" ]] && continue
 
@@ -216,16 +336,14 @@ for hooks_file in ${HOOKS_FILES[@]+"${HOOKS_FILES[@]}"}; do
     target="$hooks_dir/$rel"
     [[ -f "$target" ]] || continue
 
-    # Extract the expected export function from the hook name
-    # e.g., sfcc.app.tax.calculate -> calculate
     func_name="${hook_name##*.}"
     if ! grep -qE "exports\.$func_name\s*=|module\.exports.*$func_name" "$target" 2>/dev/null; then
-      warn "$hooks_file" "Hook '$hook_name' expects export '$func_name' but not found in $script"
+      block "$hooks_file" "Hook '$hook_name' expects export '$func_name' but not found in $script"
     fi
   done < <(jq -c '.hooks[]?' "$hooks_file" 2>/dev/null)
 done
 
-# Q3: Missing error handling in hook scripts (WARN)
+# Q3: Missing error handling in hook scripts (BLOCK)
 for hooks_file in ${HOOKS_FILES[@]+"${HOOKS_FILES[@]}"}; do
   [[ -z "$hooks_file" ]] && continue
   hooks_dir="$(dirname "$hooks_file")"
@@ -237,7 +355,7 @@ for hooks_file in ${HOOKS_FILES[@]+"${HOOKS_FILES[@]}"}; do
     [[ -f "$target" ]] || continue
 
     if ! grep -qE '\btry\b' "$target" 2>/dev/null; then
-      warn "$target" "Hook script has no try/catch error handling"
+      block "$target" "Hook script has no try/catch error handling"
     fi
   done < <(jq -r '.hooks[]?.script // empty' "$hooks_file" 2>/dev/null)
 done
@@ -245,7 +363,6 @@ done
 # Q4: Impex install/uninstall symmetry for services (BLOCK)
 install_services="$CAP_ROOT/impex/install/services.xml"
 uninstall_services="$CAP_ROOT/impex/uninstall/services.xml"
-# Also check one level deeper if the structure uses a wrapper dir
 if [[ ! -f "$install_services" ]]; then
   install_services="$(find "$CAP_ROOT" -path '*/impex/install/services.xml' -print -quit 2>/dev/null || true)"
 fi
@@ -272,26 +389,34 @@ if [[ -n "$install_services" && -f "$install_services" ]]; then
         [[ "$id" == "$uid" ]] && found=true && break
       done
       if [[ "$found" == "false" ]]; then
-        warn "$uninstall_services" "Service $id in install but missing from uninstall"
+        block "$uninstall_services" "Service $id in install but missing from uninstall"
       fi
     done
   fi
 fi
 
-# Q5: SITEID placeholder check in impex (WARN)
+# Q5: SITEID placeholder check in impex (BLOCK)
 for f in ${XML_FILES[@]+"${XML_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
   while IFS= read -r line; do
-    warn "$f" "Hardcoded site-id — use SITEID placeholder: $line"
+    block "$f" "Hardcoded site-id — use SITEID placeholder: $line"
   done < <(grep -nE 'site-id="[^"]*"' "$f" 2>/dev/null | grep -v 'SITEID' | grep -v 'mode="delete"' | head -3)
 done
 
-# Q6: Absolute paths in code (WARN)
+# Q6: Absolute paths in code (BLOCK)
 for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
   [[ -z "$f" ]] && continue
   while IFS= read -r line; do
-    warn "$f" "Absolute path detected — use relative paths: $line"
-  done < <(grep -nE "['\"]/usr/|['\"]/tmp/|['\"]/home/|['\"]/var/|['\"]C:\\\\" "$f" 2>/dev/null | grep -v '^\s*//' | head -3)
+    block "$f" "Absolute path detected — use relative paths: $line"
+  done < <(grep -nE "['\"]/usr/|['\"]/tmp/|['\"]/home/|['\"]/var/|['\"]C:\\\\" "$f" 2>/dev/null | strip_comments | head -3)
+done
+
+# Q7: console.log in production cartridge code (BLOCK)
+for f in ${JS_FILES[@]+"${JS_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    block "$f" "console.log/debug statement in cartridge code — use dw.system.Logger: $line"
+  done < <(grep -nE 'console\.(log|debug|info|warn|error)\s*\(' "$f" 2>/dev/null | strip_comments | head -5)
 done
 
 echo ""

--- a/.github/scripts/test-security-scan.sh
+++ b/.github/scripts/test-security-scan.sh
@@ -12,11 +12,9 @@ cleanup() { [[ -n "$TMPDIR_ROOT" ]] && rm -rf "$TMPDIR_ROOT"; }
 trap cleanup EXIT
 TMPDIR_ROOT="$(mktemp -d)"
 
-_DC=0
 mkcap() {
-  _DC=$((_DC + 1))
-  local d="$TMPDIR_ROOT/cap_${_DC}"
-  mkdir -p "$d"
+  local d
+  d="$(mktemp -d "$TMPDIR_ROOT/cap_XXXXXX")"
   printf '%s' "$d"
 }
 
@@ -139,12 +137,11 @@ assert_blocks "eval() in code" "$cap"
 cap="$(mkcap)"; printf 'var fn = new Function("return x");\n' > "$cap/app.js"
 assert_blocks "new Function() in code" "$cap"
 
-# BUG: grep -n prefixes "1://" so grep -v '^\s*//' never matches the comment.
 cap="$(mkcap)"; printf '// eval(input);\n' > "$cap/app.js"
-assert_known_bug "S1-COMMENT" "eval in line comment should be ignored" "pass" "$cap"
+assert_passes "eval in line comment is ignored" "$cap"
 
 cap="$(mkcap)"; printf '// new Function("return x");\n' > "$cap/app.js"
-assert_known_bug "S1-COMMENT" "new Function in comment should be ignored" "pass" "$cap"
+assert_passes "new Function in line comment is ignored" "$cap"
 
 echo ""
 
@@ -194,12 +191,11 @@ assert_blocks "Slack token" "$cap"
 cap="$(mkcap)"; printf 'var x = "sk_live_abc123defgh";\n' > "$cap/app.js"
 assert_blocks "Stripe-style live key" "$cap"
 
-# BUG: grep parses "-----BEGIN" as --BEGIN flag; pattern never matches.
 cap="$(mkcap)"; printf 'var k = "-----BEGIN RSA PRIVATE KEY-----";\n' > "$cap/app.js"
-assert_known_bug "S4-PRIVKEY" "RSA private key header should block" "block" "$cap"
+assert_blocks "RSA private key header blocks" "$cap"
 
 cap="$(mkcap)"; printf 'var k = "-----BEGIN PRIVATE KEY-----";\n' > "$cap/app.js"
-assert_known_bug "S4-PRIVKEY" "generic private key header should block" "block" "$cap"
+assert_blocks "generic private key header blocks" "$cap"
 
 echo ""
 
@@ -230,59 +226,379 @@ assert_warns "Math.random() warns" "Math.random()" "$cap"
 echo ""
 
 # ---------------------------------------------------------------------------
-# S7: Inline Authorization header
+# S7: Inline Authorization header (BLOCK)
 # ---------------------------------------------------------------------------
 echo "--- S7: Inline Authorization ---"
 
 cap="$(mkcap)"; printf "req.setRequestHeader('Authorization', token);\n" > "$cap/app.js"
-assert_warns "setRequestHeader Authorization warns" "Inline Authorization" "$cap"
+assert_blocks "setRequestHeader Authorization blocks" "$cap"
 
 echo ""
 
 # ---------------------------------------------------------------------------
-# P1: console.log
+# S8: Additional DOM sinks (BLOCK)
 # ---------------------------------------------------------------------------
-echo "--- P1: console.log ---"
+echo "--- S8: Additional DOM sinks ---"
 
-cap="$(mkcap)"; printf 'console.log("debug");\n' > "$cap/cart.js"
-assert_warns "console.log warns" "console.log" "$cap"
+cap="$(mkcap)"; printf 'el.outerHTML = data;\n' > "$cap/app.js"
+assert_blocks "outerHTML assignment detected" "$cap"
+
+cap="$(mkcap)"; printf 'var x = el.outerHTML;\n' > "$cap/app.js"
+assert_passes "outerHTML read is safe (no assignment)" "$cap"
+
+cap="$(mkcap)"; printf "document['write'](html);\n" > "$cap/app.js"
+assert_blocks "document write call detected" "$cap"
+
+cap="$(mkcap)"; printf "document['writeln'](html);\n" > "$cap/app.js"
+assert_blocks "document writeln call detected" "$cap"
+
+cap="$(mkcap)"; printf 'el.insertAdjacentHTML("beforeend", data);\n' > "$cap/app.js"
+assert_blocks "insertAdjacentHTML detected" "$cap"
+
+cap="$(mkcap)"; printf '// el.outerHTML = data;\n' > "$cap/app.js"
+assert_passes "outerHTML in comment is ignored" "$cap"
+
+cap="$(mkcap)"; printf "// document['write'](html);\n" > "$cap/app.js"
+assert_passes "document write in comment is ignored" "$cap"
 
 echo ""
 
 # ---------------------------------------------------------------------------
-# P2: HTTPClient without timeout
+# S9: ISML template injection (BLOCK)
 # ---------------------------------------------------------------------------
-echo "--- P2: HTTPClient timeout ---"
+echo "--- S9: ISML template injection ---"
 
-cap="$(mkcap)"; printf 'var c = new HTTPClient();\nc.open("GET", url);\n' > "$cap/svc.js"
-assert_warns "HTTPClient without timeout warns" "HTTPClient used without explicit timeout" "$cap"
+cap="$(mkcap)"; printf '<isprint value="${pdict.data}" encoding="off"/>\n' > "$cap/template.isml"
+assert_blocks "encoding off detected" "$cap"
 
-# BUG: grep -qE 'setTimeout\|...' uses \| which is literal in ERE mode, not alternation.
-# setTimeout is never recognized, so HTTPClient with setTimeout still warns falsely.
-cap="$(mkcap)"; printf 'var c = new HTTPClient();\nc.setTimeout(5000);\n' > "$cap/svc.js"
+cap="$(mkcap)"; printf '<isprint value="${pdict.data}" encoding="htmlcontent"/>\n' > "$cap/template.isml"
+assert_passes "proper encoding is safe" "$cap"
+
+cap="$(mkcap)"; printf '<isprint value="${pdict.data}"/>\n' > "$cap/template.isml"
+assert_passes "default encoding is safe" "$cap"
+
+cap="$(mkcap)"
+assert_passes "no ISML files in package — handled gracefully" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S10: Secret files in package (BLOCK)
+# ---------------------------------------------------------------------------
+echo "--- S10: Secret files ---"
+
+cap="$(mkcap)"; touch "$cap/.env"
+assert_blocks "dotenv file detected" "$cap"
+
+cap="$(mkcap)"; touch "$cap/production.env"
+assert_blocks "named .env file detected" "$cap"
+
+cap="$(mkcap)"; touch "$cap/server.key"
+assert_blocks "key file detected" "$cap"
+
+cap="$(mkcap)"; touch "$cap/cert.pem"
+assert_blocks "PEM file detected" "$cap"
+
+cap="$(mkcap)"; touch "$cap/keystore.p12"
+assert_blocks "P12 file detected" "$cap"
+
+cap="$(mkcap)"; touch "$cap/store.pfx"
+assert_blocks "PFX file detected" "$cap"
+
+cap="$(mkcap)"; touch "$cap/keys.jks"
+assert_blocks "JKS file detected" "$cap"
+
+cap="$(mkcap)"; printf 'readme\n' > "$cap/readme.md"; printf 'app()\n' > "$cap/app.js"
+assert_passes "normal files don't trigger" "$cap"
+
+cap="$(mkcap)"; printf '{}' > "$cap/data.json"
+assert_passes "non-secret extensions safe" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S11: Raw HTTP outside service framework (BLOCK)
+# ---------------------------------------------------------------------------
+echo "--- S11: Direct HTTPClient ---"
+
+cap="$(mkcap)"; printf 'var c = new HTTPClient();\n' > "$cap/svc.js"
+assert_blocks "direct HTTPClient usage" "$cap"
+
+cap="$(mkcap)"; printf '// var c = new HTTPClient();\n' > "$cap/svc.js"
+assert_passes "HTTPClient in line comment is ignored" "$cap"
+
+cap="$(mkcap)"; printf '/* HTTPClient docs */\n' > "$cap/svc.js"
+assert_passes "HTTPClient in block comment is ignored" "$cap"
+
+cap="$(mkcap)"; printf 'LocalServiceRegistry.createService("my.svc", {});\n' > "$cap/svc.js"
+assert_passes "service framework usage is safe" "$cap"
+
+cap="$(mkcap)"; printf 'var c = new HTTPClient();\n' > "$cap/svc.ts"
+assert_blocks "also detects in TypeScript" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S12: Sensitive data in logs (WARN)
+# ---------------------------------------------------------------------------
+echo "--- S12: Sensitive data in logs ---"
+
+cap="$(mkcap)"; printf 'Logger.info("password=" + password);\n' > "$cap/app.js"
+assert_warns "PII field name in Logger" "Possible PII" "$cap"
+
+cap="$(mkcap)"; printf 'Logger.error("creditCard: " + card);\n' > "$cap/app.js"
+assert_warns "creditCard field in Logger" "Possible PII" "$cap"
+
+cap="$(mkcap)"; printf 'log.debug("ssn=" + val);\n' > "$cap/app.js"
+assert_warns "ssn via log.debug" "Possible PII" "$cap"
+
+cap="$(mkcap)"; printf 'Logger.info("Request processed successfully");\n' > "$cap/app.js"
+assert_no_warning "no PII field names" "Possible PII" "$cap"
+
+cap="$(mkcap)"; printf 'Logger.info("password policy updated");\n' > "$cap/app.js"
+assert_warns "false positive acceptable — WARN only" "Possible PII" "$cap"
+
+cap="$(mkcap)"; printf '// Logger.info("password=" + pw);\n' > "$cap/app.js"
+assert_no_warning "commented out is ignored" "Possible PII" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S13: Blocking/sleep in hooks (BLOCK)
+# ---------------------------------------------------------------------------
+echo "--- S13: Blocking/sleep in hooks ---"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { setTimeout(fn, 5000); } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_blocks "setTimeout in hook" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { setInterval(poll, 1000); } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_blocks "setInterval in hook" "$cap"
+
+cap="$(mkcap)"; printf 'setTimeout(fn, 100);\n' > "$cap/util.js"
+assert_passes "setTimeout outside hooks is not checked" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { return compute(); } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_passes "clean hook passes" "$cap"
+
+cap="$(mkcap)"; printf 'setTimeout(fn, 100);\n' > "$cap/app.js"
+assert_passes "HOOKS_FILES empty, S13 skipped" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S14: Unbounded loops (BLOCK)
+# ---------------------------------------------------------------------------
+echo "--- S14: Unbounded loops ---"
+
+cap="$(mkcap)"; printf 'while(true) { doWork(); }\n' > "$cap/app.js"
+assert_blocks "while-true without break" "$cap"
+
+cap="$(mkcap)"; printf 'for(;;) { process(); }\n' > "$cap/app.js"
+assert_blocks "for-ever without break" "$cap"
+
+cap="$(mkcap)"; printf 'while(true) { if (done) break; doWork(); }\n' > "$cap/app.js"
+assert_passes "while-true with break within 20 lines" "$cap"
+
+cap="$(mkcap)"; printf 'for(;;) { if (x) return result; work(); }\n' > "$cap/app.js"
+assert_passes "for-ever with return within 20 lines" "$cap"
+
+cap="$(mkcap)"; printf '// while(true) { }\n' > "$cap/app.js"
+assert_passes "loop in line comment is ignored" "$cap"
+
+cap="$(mkcap)"; printf 'while (condition) { work(); }\n' > "$cap/app.js"
+assert_passes "bounded loop is not flagged" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S15: Missing rate limiting / circuit breaker (BLOCK)
+# ---------------------------------------------------------------------------
+echo "--- S15: Rate limiting / circuit breaker ---"
+
+# Test 1: tax domain missing rate limiting
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"tax"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
 run_scan "$cap"
-if [[ "$LAST_RC" -eq 0 ]] && echo "$LAST_OUTPUT" | grep -qF "HTTPClient used without explicit timeout"; then
-  echo "  BUG:  HTTPClient with setTimeout still warns [P2-TIMEOUT — \\| is literal in ERE]"
-  BUGS=$((BUGS + 1))
+if [[ "$LAST_RC" -eq 1 ]] && echo "$LAST_OUTPUT" | grep -qF "tax"; then
+  echo "  PASS: tax app missing rate limiting — blocks with tax ideal values"
+  PASS=$((PASS + 1))
 else
-  echo "  FIXED? HTTPClient with setTimeout no longer warns [P2-TIMEOUT — review this test]"
+  echo "  FAIL: tax app missing rate limiting (expected block + tax in output, got exit $LAST_RC)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 2: payment domain missing circuit breaker
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"payment"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>10000</timeout-millis><rate-limit-enabled>true</rate-limit-enabled></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+run_scan "$cap"
+if [[ "$LAST_RC" -eq 1 ]] && echo "$LAST_OUTPUT" | grep -qF "payment"; then
+  echo "  PASS: payment app missing circuit breaker — blocks with payment ideal values"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: payment app missing circuit breaker (expected block + payment in output, got exit $LAST_RC)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 3: shipping domain missing both
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"shipping"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+run_scan "$cap"
+if [[ "$LAST_RC" -eq 1 ]] && echo "$LAST_OUTPUT" | grep -qF "shipping"; then
+  echo "  PASS: shipping app missing both — blocks with shipping ideal values"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: shipping app missing both (expected block + shipping in output, got exit $LAST_RC)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 4: non-provider domain (loyalty) missing both
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"loyalty"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>10000</timeout-millis></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+run_scan "$cap"
+if [[ "$LAST_RC" -eq 1 ]] && echo "$LAST_OUTPUT" | grep -qF "loyalty"; then
+  echo "  PASS: loyalty app missing both — blocks with default ideal values"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: loyalty app missing both (expected block + loyalty in output, got exit $LAST_RC)"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 5: fully configured profile passes
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"tax"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis><rate-limit-enabled>true</rate-limit-enabled><circuit-breaker-enabled>true</circuit-breaker-enabled></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+assert_passes "fully configured profile passes" "$cap"
+
+# Test 6: shorthand cb-enabled accepted
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"tax"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis><rate-limit-enabled>true</rate-limit-enabled><cb-enabled>true</cb-enabled></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+assert_passes "shorthand cb-enabled accepted" "$cap"
+
+# Test 7: explicit false still blocks
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"tax"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis><rate-limit-enabled>false</rate-limit-enabled><circuit-breaker-enabled>true</circuit-breaker-enabled></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+assert_blocks "explicit false still blocks (strict)" "$cap"
+
+# Test 8: rate-limit but no circuit breaker
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"tax"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis><rate-limit-enabled>true</rate-limit-enabled></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+assert_blocks "missing circuit breaker blocks" "$cap"
+
+# Test 9: circuit breaker but no rate limiting
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '{"domain":"tax"}\n' > "$cap/commerce-app.json"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis><circuit-breaker-enabled>true</circuit-breaker-enabled></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+assert_blocks "missing rate limiting blocks" "$cap"
+
+# Test 10: uninstall dir skipped
+cap="$(mkcap)"; mkdir -p "$cap/impex/uninstall"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis></service-profile>\n' > "$cap/impex/uninstall/services.xml"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' >> "$cap/impex/uninstall/services.xml"
+assert_passes "service profile in uninstall dir skipped" "$cap"
+
+# Test 11: no service-profile tag — file skipped
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '<services><service-credential service-id="MySvc"/></services>\n' > "$cap/impex/install/creds.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/creds.xml"
+assert_passes "file without service-profile skipped" "$cap"
+
+# Test 12: no commerce-app.json — still blocks with default ideal values
+cap="$(mkcap)"; mkdir -p "$cap/impex/install"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis></service-profile>\n' > "$cap/impex/install/services.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+run_scan "$cap"
+if [[ "$LAST_RC" -eq 1 ]] && echo "$LAST_OUTPUT" | grep -qF "All others"; then
+  echo "  PASS: no commerce-app.json — blocks with default ideal values"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: no commerce-app.json (expected block + 'All others' in output, got exit $LAST_RC)"
   FAIL=$((FAIL + 1))
 fi
 
 echo ""
 
 # ---------------------------------------------------------------------------
-# P3: Service profile timeout
+# S16: Session object access (WARN)
 # ---------------------------------------------------------------------------
-echo "--- P3: Service profile timeout ---"
+echo "--- S16: Session object access ---"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf "exports.calculate = function() { try { var S = require('dw/system/Session'); } catch(e) {} };\n" > "$cap/hooks/tax.js"
+assert_warns "Session import in hook" "Session access" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { var t = session.privacy.token; } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_warns "session.privacy access in hook" "Session access" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { var d = session.custom.data; } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_warns "session.custom access in hook" "Session access" "$cap"
+
+cap="$(mkcap)"; printf "var S = require('dw/system/Session');\n" > "$cap/util.js"
+assert_no_warning "Session outside hooks is not checked" "Session access" "$cap"
+
+cap="$(mkcap)"; printf "var S = require('dw/system/Session');\n" > "$cap/util.js"
+assert_passes "HOOKS_FILES empty, S16 skipped" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { return compute(); } catch(e) {} };\n' > "$cap/hooks/tax.js"
+assert_no_warning "clean hook has no session warning" "Session access" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# P1: Service profile timeout (BLOCK)
+# ---------------------------------------------------------------------------
+echo "--- P1: Service profile timeout ---"
 
 cap="$(mkcap)"; mkdir -p "$cap/impex/install"
-printf '<service-profile service-id="MySvc"/>\n' > "$cap/impex/install/profiles.xml"
-assert_warns "service profile without timeout-millis warns" "Service profile missing" "$cap"
+printf '<service-profile service-id="MySvc"><rate-limit-enabled>true</rate-limit-enabled><circuit-breaker-enabled>true</circuit-breaker-enabled></service-profile>\n' > "$cap/impex/install/profiles.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/profiles.xml"
+assert_blocks "service profile without timeout-millis blocks" "$cap"
 
 cap="$(mkcap)"; mkdir -p "$cap/impex/install"
-printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis></service-profile>\n' > "$cap/impex/install/profiles.xml"
-assert_no_warning "service profile with timeout — no timeout warning" "Service profile missing" "$cap"
+printf '<service-profile service-id="MySvc"><timeout-millis>5000</timeout-millis><rate-limit-enabled>true</rate-limit-enabled><circuit-breaker-enabled>true</circuit-breaker-enabled></service-profile>\n' > "$cap/impex/install/profiles.xml"
+mkdir -p "$cap/impex/uninstall"
+printf '<services mode="delete"><service-credential service-id="MySvc" mode="delete"/></services>\n' > "$cap/impex/uninstall/profiles.xml"
+assert_passes "service profile with timeout passes" "$cap"
 
 cap="$(mkcap)"; mkdir -p "$cap/impex/uninstall"
 printf '<service-profile service-id="MySvc"/>\n' > "$cap/impex/uninstall/profiles.xml"
@@ -307,14 +623,14 @@ assert_passes "existing hook script with export + try/catch passes" "$cap"
 echo ""
 
 # ---------------------------------------------------------------------------
-# Q2: Hook function exported
+# Q2: Hook function exported (BLOCK)
 # ---------------------------------------------------------------------------
 echo "--- Q2: Hook function export ---"
 
 cap="$(mkcap)"; mkdir -p "$cap/hooks"
 printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
 printf 'function calculate() { try { run(); } catch(e) {} }\n' > "$cap/hooks/tax.js"
-assert_warns "unexported hook function warns" "expects export 'calculate'" "$cap"
+assert_blocks "unexported hook function blocks" "$cap"
 
 cap="$(mkcap)"; mkdir -p "$cap/hooks"
 printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
@@ -324,14 +640,14 @@ assert_no_warning "exported hook function — no export warning" "expects export
 echo ""
 
 # ---------------------------------------------------------------------------
-# Q3: Error handling in hooks
+# Q3: Error handling in hooks (BLOCK)
 # ---------------------------------------------------------------------------
 echo "--- Q3: Hook error handling ---"
 
 cap="$(mkcap)"; mkdir -p "$cap/hooks"
 printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
 printf 'exports.calculate = function() { return 1; };\n' > "$cap/hooks/tax.js"
-assert_warns "hook without try/catch warns" "no try/catch" "$cap"
+assert_blocks "hook without try/catch blocks" "$cap"
 
 cap="$(mkcap)"; mkdir -p "$cap/hooks"
 printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
@@ -359,15 +675,21 @@ printf '<services><service-credential service-id="svc1"/></services>\n' > "$cap/
 printf '<services mode="delete"><service-credential service-id="svc1" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
 assert_passes "matching install/uninstall with mode=delete passes" "$cap"
 
+# Q4 service ID mismatch now blocks
+cap="$(mkcap)"; mkdir -p "$cap/impex/install" "$cap/impex/uninstall"
+printf '<services><service-credential service-id="svc1"/><service-credential service-id="svc2"/></services>\n' > "$cap/impex/install/services.xml"
+printf '<services mode="delete"><service-credential service-id="svc1" mode="delete"/></services>\n' > "$cap/impex/uninstall/services.xml"
+assert_blocks "service ID in install but missing from uninstall blocks" "$cap"
+
 echo ""
 
 # ---------------------------------------------------------------------------
-# Q5: SITEID placeholder
+# Q5: SITEID placeholder (BLOCK)
 # ---------------------------------------------------------------------------
 echo "--- Q5: SITEID placeholder ---"
 
 cap="$(mkcap)"; printf '<site site-id="MySite"><prefs/></site>\n' > "$cap/prefs.xml"
-assert_warns "hardcoded site-id warns" "Hardcoded site-id" "$cap"
+assert_blocks "hardcoded site-id blocks" "$cap"
 
 cap="$(mkcap)"; printf '<site site-id="SITEID"><prefs/></site>\n' > "$cap/prefs.xml"
 assert_no_warning "SITEID placeholder — no site-id warning" "Hardcoded site-id" "$cap"
@@ -375,12 +697,12 @@ assert_no_warning "SITEID placeholder — no site-id warning" "Hardcoded site-id
 echo ""
 
 # ---------------------------------------------------------------------------
-# Q6: Absolute paths
+# Q6: Absolute paths (BLOCK)
 # ---------------------------------------------------------------------------
 echo "--- Q6: Absolute paths ---"
 
 cap="$(mkcap)"; printf "var p = '/tmp/data';\n" > "$cap/app.js"
-assert_warns "absolute /tmp/ path warns" "Absolute path" "$cap"
+assert_blocks "absolute /tmp/ path blocks" "$cap"
 
 cap="$(mkcap)"; printf "var p = './data';\n" > "$cap/app.js"
 assert_no_warning "relative path — no absolute path warning" "Absolute path" "$cap"
@@ -388,15 +710,43 @@ assert_no_warning "relative path — no absolute path warning" "Absolute path" "
 echo ""
 
 # ---------------------------------------------------------------------------
-# Combination: warnings don't block
+# Q7: console.log (BLOCK)
+# ---------------------------------------------------------------------------
+echo "--- Q7: console.log ---"
+
+cap="$(mkcap)"; printf 'console.log("debug");\n' > "$cap/cart.js"
+assert_blocks "console.log blocks" "$cap"
+
+cap="$(mkcap)"; printf 'console.debug("test");\n' > "$cap/cart.js"
+assert_blocks "console.debug blocks" "$cap"
+
+cap="$(mkcap)"; printf '// console.log("commented out");\n' > "$cap/cart.js"
+assert_passes "console.log in line comment is ignored" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# Combination: warnings don't block, one block + warn = exit 1
 # ---------------------------------------------------------------------------
 echo "--- Combination ---"
 
-cap="$(mkcap)"
-printf 'console.log("debug");\nvar r = Math.random();\n' > "$cap/app.js"
+# Multiple warnings don't block (Math.random + session in hook)
+cap="$(mkcap)"; mkdir -p "$cap/hooks"
+printf '{"hooks":[{"name":"sfcc.app.tax.calculate","script":"./hooks/tax.js"}]}\n' > "$cap/hooks.json"
+printf 'exports.calculate = function() { try { var r = Math.random(); var t = session.privacy.token; return r; } catch(e) {} };\n' > "$cap/hooks/tax.js"
 run_scan "$cap"
-if [[ "$LAST_RC" -eq 0 ]]; then echo "  PASS: multiple warnings still exit 0"; PASS=$((PASS + 1))
-else echo "  FAIL: multiple warnings still exit 0 (got $LAST_RC)"; FAIL=$((FAIL + 1)); fi
+if [[ "$LAST_RC" -eq 0 ]]; then echo "  PASS: multiple WARNs don't block (exit 0)"; PASS=$((PASS + 1))
+else echo "  FAIL: multiple WARNs don't block (expected exit 0, got $LAST_RC)"; FAIL=$((FAIL + 1)); fi
+
+# One BLOCK + one WARN = exit 1
+cap="$(mkcap)"; printf 'var r = Math.random();\nvar x = eval("code");\n' > "$cap/app.js"
+run_scan "$cap"
+if [[ "$LAST_RC" -eq 1 ]]; then echo "  PASS: one BLOCK + one WARN = exit 1"; PASS=$((PASS + 1))
+else echo "  FAIL: one BLOCK + one WARN = exit 1 (got $LAST_RC)"; FAIL=$((FAIL + 1)); fi
+
+# Empty CAP directory
+cap="$(mkcap)"
+assert_clean "empty dir is clean" "$cap"
 
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed, $BUGS known bugs ==="

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,7 +1,6 @@
 name: Security Review
 
 permissions:
-  pull-requests: write  # Needed for leaving PR comments
   contents: read
 
 on:
@@ -66,3 +65,4 @@ jobs:
           while IFS= read -r dir; do
             bash .github/scripts/security-scan.sh "$dir"
           done < /tmp/cap-roots.txt
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,7 @@ Your response:
 - Semantic versioning: `major.minor.patch`
 - Version in `commerce-app.json` MUST match `manifest.json`
 - SHA256 in `manifest.json` MUST match actual ZIP hash
+- **When you modify any file inside a `commerce-{app-name}-app-v*/` directory, you MUST re-package the ZIP and update the SHA256 hash in `manifest.json` before finishing.** Do not wait for the user to ask — the ZIP is stale as soon as a source file changes.
 - Do NOT add new versions to `catalog.json` when updating (CI handles it)
 - You MAY add `"deprecated": true` to existing versions in `catalog.json`
 
@@ -134,6 +135,13 @@ Your response:
 - Use placeholders for API keys/secrets
 - Use `<password>` type for sensitive site preferences
 - Mark sensitive data clearly in documentation
+- NO secret files (`.env`, `.key`, `.pem`, `.p12`, `.pfx`, `.jks`) in packages
+- NO direct `HTTPClient` usage — must use service framework
+- NO `innerHTML`/`outerHTML` assignment, `insertAdjacentHTML`, or document write methods
+- NO `setTimeout`/`setInterval` in hook scripts
+- NO unbounded loops (`while(true)` / `for(;;)`) without break/return
+- NO ISML `<isprint>` with `encoding="off"`
+- ALL apps with services MUST have rate limiting AND circuit breaker enabled on service profiles
 
 ### 5. Impex Rules
 - Service install files MUST have matching uninstall files
@@ -146,6 +154,7 @@ Your response:
 - Single root folder: `commerce-{app-name}-app-v{version}/`
 - NO junk files: `.DS_Store`, `__MACOSX`, `Thumbs.db`, hidden files
 - NO `node_modules`, `.git`, IDE files
+- NO secret files (`.env`, `.key`, `.pem`, `.p12`, `.pfx`, `.jks`)
 - Optional: `icons/` directory with ISV icon(s)
 - Use exclusions when creating ZIP:
   ```bash
@@ -470,6 +479,12 @@ Before suggesting `/submit-app-pr`, verify:
 - [ ] No sensitive data in XML
 - [ ] Passwords use `<password>` type
 - [ ] API keys are placeholders
+- [ ] No direct HTTPClient usage (use service framework)
+- [ ] No secret files in package (.env, .key, .pem, .p12, .pfx, .jks)
+- [ ] No eval/innerHTML/outerHTML/insertAdjacentHTML/document write
+- [ ] Hook scripts have try/catch, export expected functions, no setTimeout/setInterval
+- [ ] No unbounded loops without exit conditions
+- [ ] All service profiles have rate-limit-enabled=true AND circuit-breaker-enabled=true (or cb-enabled=true)
 
 ## Helping Developers Effectively
 


### PR DESCRIPTION
## Summary

- Add 9 new scanner rules (S8–S16) covering DOM sinks, ISML injection, secret files, direct HTTPClient, PII in logs, blocking calls in hooks, unbounded loops, rate limiting/circuit breaker enforcement, and session access in hooks
- Promote 9 existing rules from WARN to BLOCK severity, remove P2 (subsumed by S11)
- Remove Claude Security Review and Prompt Injection Scan from CI workflow — AI review should not run against ISV submissions in the production registry
- Coverage: 24 threats, 21 BLOCK, 3 WARN — test suite: 106 pass, 0 fail

## Test plan

- [x] `test-security-scan.sh` passes (106/106)
- [x] CI security workflow runs successfully on this PR
- [x] Validate existing app ZIPs still pass/fail as expected