### PR TITLE
@W-22470579 | Add Task List & Translation Validations to /validate-app

### DIFF
--- a/.claude/skills/validate-app/SKILL.md
+++ b/.claude/skills/validate-app/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 
 Run comprehensive validation checks on a commerce app before submitting a PR.
 
-## Step 1: Identify app
+## Step 1: Identify app and resolve input
 
 Gather:
 - Domain (e.g., `tax`, `payment`, `shipping`)
@@ -21,20 +21,45 @@ Gather:
 
 **Structure:** Apps must be at `{domain}/{appName}/` where `{appName}` matches the "id" field. See `references/folder-structure.md`.
 
-## Step 2: Verify ZIP exists
+The skill accepts **either** a packaged `.zip` **or** an already-extracted CAP root directory (e.g., `commerce-<appName>-app-v<version>/`). Set both variables once; later steps branch on `INPUT_KIND`:
 
 ```bash
-ls -lh <domain>/<appName>/<appName>-v<version>.zip
+# Resolve the input: a .zip path OR an extracted CAP root directory.
+INPUT="<path-to-zip-or-extracted-cap-root>"
+if [[ -f "$INPUT" && "$INPUT" == *.zip ]]; then
+  INPUT_KIND=zip
+  ZIP="$INPUT"
+  EXTRACT_DIR="$(mktemp -d)"
+  unzip -q "$ZIP" -d "$EXTRACT_DIR"
+  CAP_ROOT="$EXTRACT_DIR/commerce-<appName>-app-v<version>"
+elif [[ -d "$INPUT" ]]; then
+  INPUT_KIND=dir
+  CAP_ROOT="$INPUT"
+  ZIP=""        # no zip available — Step 3 will be skipped
+  EXTRACT_DIR="" # nothing to clean up in Step 14
+else
+  echo "Input must be a .zip file or extracted CAP root directory" >&2; exit 2
+fi
+```
+
+## Step 2: Verify input exists
+
+```bash
+if [[ "$INPUT_KIND" == "zip" ]]; then ls -lh "$ZIP"; else ls -ld "$CAP_ROOT"; fi
 ```
 
 ## Step 3: Validate SHA256
 
-```bash
-# Compute hash
-shasum -a 256 <domain>/<appName>/<appName>-v<version>.zip
+**Skip if `INPUT_KIND=dir`** — the manifest pins a hash of the `.zip` artifact, which can't be reproduced from extracted files. Note this gap in the report and re-run Step 3 once the ZIP is built.
 
-# Compare with commerce-apps-manifest/manifest.json
-jq '.[] | .[] | select(.id == "<appName>")' commerce-apps-manifest/manifest.json
+```bash
+if [[ "$INPUT_KIND" == "zip" ]]; then
+  shasum -a 256 "$ZIP"
+  jq '[.[] | select(type=="array")] | flatten | .[] | select(.id == "<appName>") | .sha256' \
+    commerce-apps-manifest/manifest.json
+else
+  echo "(skipped — no ZIP available; SHA256 must be re-checked against the built ZIP)"
+fi
 ```
 
 Hashes must match exactly.
@@ -62,23 +87,35 @@ Optional fields (validate if present):
 - Only `sfnext` and `sfra` keys allowed inside `storefrontSupport`; only `minVersion` and `maxVersion` allowed inside each
 - `storefrontSupport` must be present in **both** the root manifest and `commerce-app.json` with matching values
 
-## Step 5: Validate ZIP contents
+## Step 5: Validate package contents
 
 ```bash
-unzip -l <domain>/<appName>/<appName>-v<version>.zip | head -30
+if [[ "$INPUT_KIND" == "zip" ]]; then
+  unzip -l "$ZIP" | head -30
+  unzip -l "$ZIP" | grep -E "\.DS_Store|__MACOSX" || echo "  ✓ no junk files"
+else
+  ls -la "$CAP_ROOT" | head -30
+  find "$CAP_ROOT" \( -name '.DS_Store' -o -name '__MACOSX' \) -print | head \
+    || echo "  ✓ no junk files"
+fi
+
+# Required files (works for both inputs)
+for f in commerce-app.json README.md app-configuration/tasksList.json; do
+  [[ -e "$CAP_ROOT/$f" ]] && echo "  ✓ $f" || echo "  ✗ MISSING: $f"
+done
 ```
 
 Check:
-- Single root: `commerce-<appName>-app-v<version>/`
+- Single root: `commerce-<appName>-app-v<version>/` (ZIP only — for `INPUT_KIND=dir`, the directory IS the root)
 - No junk files (`.DS_Store`, `__MACOSX`, hidden files)
-- No registry paths (`tax/`, `domain/`)
+- No registry paths (`tax/`, `domain/`) at the ZIP root (ZIP only)
 - Required: `commerce-app.json`, `README.md`, `app-configuration/tasksList.json`
 
 ## Step 6: Detect architecture
 
 ```bash
-HAS_UI=$(unzip -l <zip> | grep -c "storefront-next/" || echo 0)
-HAS_BACKEND=$(unzip -l <zip> | grep -c "cartridges/" || echo 0)
+HAS_UI=$([[ -d "$CAP_ROOT/storefront-next" ]] && echo 1 || echo 0)
+HAS_BACKEND=$([[ -d "$CAP_ROOT/cartridges" ]] && echo 1 || echo 0)
 ```
 
 Determine:
@@ -88,10 +125,8 @@ Determine:
 
 ## Step 7: Validate commerce-app.json
 
-Extract and check:
-
 ```bash
-unzip -p <zip> */commerce-app.json | jq .
+jq . "$CAP_ROOT/commerce-app.json"
 ```
 
 Required fields:
@@ -111,19 +146,29 @@ Optional fields (validate if present):
 
 **Skip if Backend-only.**
 
-Check for:
-- `storefront-next/src/extensions/<appName>/target-config.json`
-- `storefront-next/src/extensions/<appName>/index.ts`
-- Required locales: `en-US/`, `en-GB/`, `it-IT/`
+Required:
+- `storefront-next/src/extensions/<appName>/target-config.json` — entry point; declares `components[]`, `actionHooks[]`, etc., each pointing at a `path` under the extension directory.
+
+For each entry referenced from `target-config.json`, verify the file exists:
+
+```bash
+TC="$CAP_ROOT/storefront-next/src/extensions/<appName>/target-config.json"
+jq -r '[.components[]?.path, .actionHooks[]?.handler, .routes[]?.handler] | .[] | select(.)' "$TC" \
+  | while read -r p; do
+      [[ -f "$CAP_ROOT/storefront-next/src/$p" ]] \
+        && echo "  ✓ $p" \
+        || echo "  ✗ MISSING: $p"
+    done
+```
+
+If the extension ships translations, they live under `storefront-next/src/extensions/<appName>/locales/<locale>/translations.json`. Locale set is app-specific — not a fixed allowlist.
 
 ## Step 9: Validate impex (Backend-only/Fullstack)
 
 **Skip if UI-only.**
 
 ```bash
-# Extract and validate XML
-unzip -q <zip>
-find commerce-<appName>-app-v<version>/impex/ -name "*.xml" -exec xmllint --noout {} \;
+find "$CAP_ROOT/impex/" -name "*.xml" -exec xmllint --noout {} \;
 ```
 
 See `references/impex-validation.md` for detailed rules:
@@ -144,40 +189,27 @@ See `references/impex-validation.md` for detailed rules:
 }
 ```
 
-## Step 10b: Validate adminComponents.json (optional)
+## Step 10b: Validate app-configuration/ JSON via CI scripts
 
-If the CAP includes `app-configuration/adminComponents.json`, verify it matches the schema CI enforces:
+Run the same scripts CI runs against `$CAP_ROOT` (already set in Step 1). Each is the source of truth for its schema; scripts print errors to stderr and exit non-zero on failure.
 
 ```bash
-unzip -p <zip> "*/app-configuration/adminComponents.json" 2>/dev/null | jq .
+# tasksList.json schema (required file)
+bash .github/scripts/validate-tasks-list.sh "$CAP_ROOT/app-configuration/tasksList.json"
+
+# adminComponents.json schema (optional file)
+[[ -f "$CAP_ROOT/app-configuration/adminComponents.json" ]] && \
+  bash .github/scripts/validate-admin-components.sh "$CAP_ROOT/app-configuration/adminComponents.json"
+
+# app-shipped translations (optional directory; cross-references the two files above)
+bash .github/scripts/validate-translations.sh "$CAP_ROOT"
 ```
 
-Required:
-- File is valid JSON and a top-level object.
-- The `configuration` key, when present, must be an array.
-- Every entry in `configuration` has a non-empty string `type`.
-- For entries with `type == "storefrontComponentVisibility"`:
-  - `attributes` is a non-empty array.
-  - Each attribute has a non-empty string `id` (the `sfcc.*` UI target identifier the merchant can toggle), a non-empty string `label` (rendered next to the toggle in BM), and a boolean `defaultValue`.
+Each script prints schema details and exits non-zero with errors on stderr. See the script header comments for the schema contract.
 
-Example:
+## Step 11: Validate manifest-level translations
 
-```json
-{
-  "configuration": [
-    {
-      "type": "storefrontComponentVisibility",
-      "attributes": [
-        { "id": "sfcc.checkout.shippingAddress.after", "label": "Show on Checkout", "defaultValue": true }
-      ]
-    }
-  ]
-}
-```
-
-Skip this step if the file isn't present — `adminComponents.json` is optional.
-
-## Step 11: Validate translations
+The CAP-internal translations live under `app-configuration/translations/` (validated in Step 10b). The **manifest-level** `commerce-apps-manifest/translations/en-US.json` holds the marketplace `name` / `description` shown on the app card:
 
 ```bash
 jq '."<appName>"' commerce-apps-manifest/translations/en-US.json
@@ -191,11 +223,11 @@ Check:
 ## Step 12: Validate icon
 
 ```bash
-# Get iconName from manifest
-ICON_NAME=$(jq -r '.[] | .[] | select(.id == "<appName>") | .iconName' commerce-apps-manifest/manifest.json)
+ICON_NAME=$(jq -r '[.[] | select(type=="array")] | flatten | .[] | select(.id == "<appName>") | .iconName' \
+  commerce-apps-manifest/manifest.json)
 
-# Check ZIP contains matching icon
-unzip -l <zip> | grep "icons/$ICON_NAME"
+[[ -f "$CAP_ROOT/icons/$ICON_NAME" ]] && echo "  ✓ icon in package" || echo "  - not in package"
+[[ -f "commerce-apps-manifest/icons/$ICON_NAME" ]] && echo "  ✓ icon in registry" || echo "  ✗ MISSING in registry"
 ```
 
 Icon filename must match `iconName` field exactly. CI extracts automatically.
@@ -203,8 +235,7 @@ Icon filename must match `iconName` field exactly. CI extracts automatically.
 ## Step 13: Security scan
 
 ```bash
-unzip -q <zip>
-bash .github/scripts/security-scan.sh commerce-<appName>-app-v<version>/
+bash .github/scripts/security-scan.sh "$CAP_ROOT/"
 ```
 
 **If blocking findings (exit 1):** FAIL - fix issues first.
@@ -214,8 +245,10 @@ See `references/security-scan.md` for details.
 
 ## Step 14: Clean up
 
+Only remove the temp dir if Step 1 created one (`INPUT_KIND=zip`). When the user passed an extracted CAP root, leave it alone.
+
 ```bash
-rm -rf commerce-<appName>-app-v<version>/
+[[ -n "$EXTRACT_DIR" ]] && rm -rf "$EXTRACT_DIR"
 ```
 
 ## Report results

--- a/.github/scripts/test-validate-tasks-list.sh
+++ b/.github/scripts/test-validate-tasks-list.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATE="$SCRIPT_DIR/validate-tasks-list.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=""
+cleanup() { [[ -n "$TMPDIR_ROOT" ]] && rm -rf "$TMPDIR_ROOT"; }
+trap cleanup EXIT
+TMPDIR_ROOT="$(mktemp -d)"
+
+LAST_OUTPUT=""
+LAST_RC=0
+
+run_validate_with_content() {
+  local content="$1"
+  local f="$TMPDIR_ROOT/case_$$_$RANDOM.json"
+  printf '%s' "$content" > "$f"
+  LAST_OUTPUT="$(bash "$VALIDATE" "$f" 2>&1)" || LAST_RC=$?
+  LAST_RC=${LAST_RC:-0}
+}
+
+assert_passes() {
+  local desc="$1"; local content="$2"
+  LAST_RC=0
+  run_validate_with_content "$content"
+  if [[ "$LAST_RC" -eq 0 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 0, got $LAST_RC)"
+    echo "    output: $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_rejects() {
+  local desc="$1"; local content="$2"; local expect_substr="$3"
+  LAST_RC=0
+  run_validate_with_content "$content"
+  if [[ "$LAST_RC" -ne 1 ]]; then
+    echo "  FAIL: $desc (expected exit 1, got $LAST_RC)"
+    echo "    output: $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$LAST_OUTPUT" != *"$expect_substr"* ]]; then
+    echo "  FAIL: $desc (output missing expected substring)"
+    echo "    expected substring: $expect_substr"
+    echo "    actual output:      $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: $desc"
+  PASS=$((PASS + 1))
+}
+
+echo "=== tasksList.json validator tests ==="
+
+# --- Passing shapes --------------------------------------------------------
+
+assert_passes "single valid task" '[
+  {"taskKey":"setup_account","name":"Setup","description":"Set up the account.","taskNumber":"1"}
+]'
+
+assert_passes "multiple sequential tasks with optional link" '[
+  {"taskKey":"setup_account","name":"Setup","description":"Set up account.","taskNumber":"1","link":"https://docs.example.com/setup"},
+  {"taskKey":"configure_keys","name":"Keys","description":"Configure API keys.","taskNumber":"2","link":""}
+]'
+
+# --- Rejecting shapes ------------------------------------------------------
+
+assert_rejects "invalid JSON is rejected" '{not json' "not valid JSON"
+
+assert_rejects "top-level object is rejected" \
+  '{"taskKey":"a","name":"n","description":"d","taskNumber":"1"}' \
+  "must be a non-empty JSON array"
+
+assert_rejects "empty array is rejected" '[]' "must be a non-empty JSON array"
+
+assert_rejects "missing taskKey is rejected" \
+  '[{"name":"n","description":"d","taskNumber":"1"}]' \
+  '"taskKey" is required'
+
+assert_rejects "empty taskKey is rejected" \
+  '[{"taskKey":"","name":"n","description":"d","taskNumber":"1"}]' \
+  '"taskKey" is required'
+
+assert_rejects "camelCase taskKey is rejected" \
+  '[{"taskKey":"setupAccount","name":"n","description":"d","taskNumber":"1"}]' \
+  '"taskKey" must match'
+
+assert_rejects "taskKey starting with digit is rejected" \
+  '[{"taskKey":"1setup","name":"n","description":"d","taskNumber":"1"}]' \
+  '"taskKey" must match'
+
+assert_rejects "missing name is rejected" \
+  '[{"taskKey":"a","description":"d","taskNumber":"1"}]' \
+  '"name" is required'
+
+assert_rejects "empty description is rejected" \
+  '[{"taskKey":"a","name":"n","description":"","taskNumber":"1"}]' \
+  '"description" is required'
+
+assert_rejects "missing taskNumber is rejected" \
+  '[{"taskKey":"a","name":"n","description":"d"}]' \
+  '"taskNumber" is required'
+
+assert_rejects "non-sequential taskNumber is rejected" \
+  '[
+    {"taskKey":"a","name":"n","description":"d","taskNumber":"1"},
+    {"taskKey":"b","name":"n","description":"d","taskNumber":"3"}
+  ]' \
+  '"taskNumber" must be "2"'
+
+assert_rejects "non-string link is rejected" \
+  '[{"taskKey":"a","name":"n","description":"d","taskNumber":"1","link":42}]' \
+  '"link" must be a string when present'
+
+assert_rejects "duplicate taskKey is rejected" \
+  '[
+    {"taskKey":"dup","name":"n","description":"d","taskNumber":"1"},
+    {"taskKey":"dup","name":"n","description":"d","taskNumber":"2"}
+  ]' \
+  "duplicate taskKey values"
+
+assert_rejects "non-object array entry is rejected" \
+  '["nope"]' \
+  "must be an object"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.github/scripts/test-validate-translations.sh
+++ b/.github/scripts/test-validate-translations.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATE="$SCRIPT_DIR/validate-translations.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=""
+cleanup() { [[ -n "$TMPDIR_ROOT" ]] && rm -rf "$TMPDIR_ROOT"; }
+trap cleanup EXIT
+TMPDIR_ROOT="$(mktemp -d)"
+
+LAST_OUTPUT=""
+LAST_RC=0
+
+# Build a CAP root from a small directive language. Each argument is one of:
+#   tasks:<filename>:<json>       (writes to app-configuration/translations/<filename>)
+#   tasksList:<json>              (writes app-configuration/tasksList.json)
+#   adminComponents:<json>        (writes app-configuration/adminComponents.json)
+#   no-translations               (skips creating translations dir)
+make_cap() {
+  local cap; cap="$(mktemp -d "$TMPDIR_ROOT/cap.XXXXXX")"
+  local has_translations=true
+  for spec in "$@"; do
+    case "$spec" in
+      no-translations)
+        has_translations=false
+        ;;
+      tasks:*)
+        local rest="${spec#tasks:}"
+        local filename="${rest%%:*}"
+        local content="${rest#*:}"
+        mkdir -p "$cap/app-configuration/translations"
+        printf '%s' "$content" > "$cap/app-configuration/translations/$filename"
+        ;;
+      tasksList:*)
+        mkdir -p "$cap/app-configuration"
+        printf '%s' "${spec#tasksList:}" > "$cap/app-configuration/tasksList.json"
+        ;;
+      adminComponents:*)
+        mkdir -p "$cap/app-configuration"
+        printf '%s' "${spec#adminComponents:}" > "$cap/app-configuration/adminComponents.json"
+        ;;
+      *)
+        echo "Unknown spec: $spec" >&2
+        exit 99
+        ;;
+    esac
+  done
+  if [[ "$has_translations" == "true" && ! -d "$cap/app-configuration/translations" ]]; then
+    mkdir -p "$cap/app-configuration/translations"
+  fi
+  echo "$cap"
+}
+
+run_validate() {
+  local cap="$1"
+  LAST_RC=0
+  LAST_OUTPUT="$(bash "$VALIDATE" "$cap" 2>&1)" || LAST_RC=$?
+  LAST_RC=${LAST_RC:-0}
+}
+
+assert_passes() {
+  local desc="$1"; shift
+  local cap; cap="$(make_cap "$@")"
+  run_validate "$cap"
+  if [[ "$LAST_RC" -eq 0 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 0, got $LAST_RC)"
+    echo "    output: $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_rejects() {
+  local desc="$1"; local expect_substr="$2"; shift 2
+  local cap; cap="$(make_cap "$@")"
+  run_validate "$cap"
+  if [[ "$LAST_RC" -ne 1 ]]; then
+    echo "  FAIL: $desc (expected exit 1, got $LAST_RC)"
+    echo "    output: $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$LAST_OUTPUT" != *"$expect_substr"* ]]; then
+    echo "  FAIL: $desc (output missing expected substring)"
+    echo "    expected substring: $expect_substr"
+    echo "    actual output:      $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: $desc"
+  PASS=$((PASS + 1))
+}
+
+echo "=== translations/ validator tests ==="
+
+# Common reusable JSON snippets.
+EN_BASIC='{"tasks":{"setup_account":{"name":"Setup","description":"Set up the account."}}}'
+DE_BASIC='{"tasks":{"setup_account":{"name":"Einrichten","description":"Konto einrichten."}}}'
+TASKS_LIST_OK='[{"taskKey":"setup_account","name":"Setup","description":"d","taskNumber":"1"}]'
+
+# --- Passing shapes --------------------------------------------------------
+
+assert_passes "missing translations dir is OK (optional)" no-translations
+
+assert_passes "en-US only" "tasks:en-US.json:$EN_BASIC"
+
+assert_passes "en-US + matching de" \
+  "tasks:en-US.json:$EN_BASIC" \
+  "tasks:de.json:$DE_BASIC"
+
+assert_passes "tasksList taskKey present in en-US" \
+  "tasks:en-US.json:$EN_BASIC" \
+  "tasksList:$TASKS_LIST_OK"
+
+assert_passes "adminComponents pair coverage and parity" \
+  "tasks:en-US.json:{\"tasks\":{\"setup_account\":{\"name\":\"S\",\"description\":\"d\"}},\"adminComponents\":{\"component_visibility\":{\"attributes\":{\"sfcc.checkout.shippingAddress.after\":{\"label\":\"Show on Checkout\"}}}}}" \
+  "tasks:de.json:{\"tasks\":{\"setup_account\":{\"name\":\"S\",\"description\":\"d\"}},\"adminComponents\":{\"component_visibility\":{\"attributes\":{\"sfcc.checkout.shippingAddress.after\":{\"label\":\"Beim Checkout\"}}}}}" \
+  "adminComponents:{\"configuration\":[{\"componentKey\":\"component_visibility\",\"type\":\"storefrontComponentVisibility\",\"attributes\":[{\"id\":\"sfcc.checkout.shippingAddress.after\",\"label\":\"Show on Checkout\",\"defaultValue\":true}]}]}"
+
+# --- Rejecting shapes ------------------------------------------------------
+
+assert_rejects "translations dir without en-US.json is rejected" \
+  "en-US.json is missing" \
+  "tasks:de.json:$DE_BASIC"
+
+assert_rejects "invalid JSON locale is rejected" \
+  "not valid JSON" \
+  "tasks:en-US.json:{not json"
+
+assert_rejects "missing tasks key is rejected" \
+  'missing or non-object "tasks" key' \
+  'tasks:en-US.json:{"foo":1}'
+
+assert_rejects "empty name in en-US is rejected" \
+  "missing/invalid name or description" \
+  'tasks:en-US.json:{"tasks":{"setup_account":{"name":"","description":"d"}}}'
+
+assert_rejects "unsupported locale filename is rejected" \
+  "Unsupported locale file" \
+  "tasks:en-US.json:$EN_BASIC" \
+  "tasks:xx-YY.json:$EN_BASIC"
+
+assert_rejects "tasksList taskKey missing from en-US is rejected" \
+  "not present in translations/en-US.json" \
+  "tasks:en-US.json:$EN_BASIC" \
+  'tasksList:[{"taskKey":"missing_task","name":"M","description":"d","taskNumber":"1"}]'
+
+assert_rejects "non-default locale missing a task key is rejected" \
+  "tasks key parity mismatch" \
+  'tasks:en-US.json:{"tasks":{"a":{"name":"A","description":"a"},"b":{"name":"B","description":"b"}}}' \
+  'tasks:de.json:{"tasks":{"a":{"name":"A","description":"a"}}}'
+
+assert_rejects "non-default locale with extra task key is rejected" \
+  "tasks key parity mismatch" \
+  'tasks:en-US.json:{"tasks":{"a":{"name":"A","description":"a"}}}' \
+  'tasks:de.json:{"tasks":{"a":{"name":"A","description":"a"},"b":{"name":"B","description":"b"}}}'
+
+assert_rejects "locale adminComponents attribute with empty label is rejected" \
+  "adminComponents shape invalid" \
+  "tasks:en-US.json:{\"tasks\":{\"setup_account\":{\"name\":\"S\",\"description\":\"d\"}},\"adminComponents\":{\"component_visibility\":{\"attributes\":{\"sfcc.checkout.shippingAddress.after\":{\"label\":\"\"}}}}}"
+
+assert_rejects "adminComponents pair missing from en-US is rejected" \
+  "not present in translations/en-US.json" \
+  "tasks:en-US.json:{\"tasks\":{\"setup_account\":{\"name\":\"S\",\"description\":\"d\"}},\"adminComponents\":{}}" \
+  "adminComponents:{\"configuration\":[{\"componentKey\":\"component_visibility\",\"type\":\"storefrontComponentVisibility\",\"attributes\":[{\"id\":\"sfcc.checkout.shippingAddress.after\",\"label\":\"Show\",\"defaultValue\":true}]}]}"
+
+assert_rejects "adminComponents parity mismatch in non-default locale is rejected" \
+  "adminComponents key parity mismatch" \
+  "tasks:en-US.json:{\"tasks\":{\"setup_account\":{\"name\":\"S\",\"description\":\"d\"}},\"adminComponents\":{\"component_visibility\":{\"attributes\":{\"sfcc.checkout.shippingAddress.after\":{\"label\":\"Show on Checkout\"}}}}}" \
+  "tasks:de.json:{\"tasks\":{\"setup_account\":{\"name\":\"S\",\"description\":\"d\"}},\"adminComponents\":{}}" \
+  "adminComponents:{\"configuration\":[{\"componentKey\":\"component_visibility\",\"type\":\"storefrontComponentVisibility\",\"attributes\":[{\"id\":\"sfcc.checkout.shippingAddress.after\",\"label\":\"Show on Checkout\",\"defaultValue\":true}]}]}"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.github/scripts/validate-tasks-list.sh
+++ b/.github/scripts/validate-tasks-list.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Validate the shape of an app-configuration/tasksList.json file.
+#
+# Usage: validate-tasks-list.sh <path-to-tasksList.json>
+#
+# Exit codes:
+#   0 - file is valid
+#   1 - file is invalid (errors printed to stderr)
+#   2 - usage error (bad args or unreadable file)
+#
+# Schema:
+#   - Top-level must be a non-empty JSON array.
+#   - Each entry is an object with:
+#       Required: taskKey (string, ^[a-z][a-z0-9_]*$, unique per file),
+#                 name (non-empty string),
+#                 description (non-empty string),
+#                 taskNumber (non-empty string, sequential from "1").
+#       Optional: link (string, may be empty).
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $(basename "$0") <path-to-tasksList.json>" >&2
+  exit 2
+fi
+
+file="$1"
+
+if [[ ! -f "$file" ]]; then
+  echo "File not found: $file" >&2
+  exit 2
+fi
+
+if ! jq empty "$file" 2>/dev/null; then
+  echo "tasksList.json is not valid JSON" >&2
+  exit 1
+fi
+
+if ! jq -e 'type == "array" and length > 0' "$file" >/dev/null 2>&1; then
+  echo "tasksList.json must be a non-empty JSON array" >&2
+  exit 1
+fi
+
+errors="$(jq -r '
+  [to_entries[] |
+   .key as $idx |
+   .value as $task |
+   (
+     if ($task | type) != "object" then
+       "Item at index \($idx): must be an object"
+     elif ($task.taskKey | type) != "string" or ($task.taskKey | length) == 0 then
+       "Item at index \($idx): \"taskKey\" is required and must be a non-empty string"
+     elif ($task.taskKey | test("^[a-z][a-z0-9_]*$")) | not then
+       "Item at index \($idx): \"taskKey\" must match ^[a-z][a-z0-9_]*$ (snake_case, got \"\($task.taskKey)\")"
+     elif ($task.name | type) != "string" or ($task.name | length) == 0 then
+       "Item at index \($idx): \"name\" is required and must be a non-empty string"
+     elif ($task.description | type) != "string" or ($task.description | length) == 0 then
+       "Item at index \($idx): \"description\" is required and must be a non-empty string"
+     elif ($task.taskNumber | type) != "string" or ($task.taskNumber | length) == 0 then
+       "Item at index \($idx): \"taskNumber\" is required and must be a non-empty string"
+     elif $task.taskNumber != ($idx + 1 | tostring) then
+       "Item at index \($idx): \"taskNumber\" must be \"\($idx + 1)\" (got \"\($task.taskNumber)\")"
+     elif ($task | has("link")) and (($task.link | type) != "string") then
+       "Item at index \($idx): \"link\" must be a string when present"
+     else
+       empty
+     end
+   )] | join("\n")
+' "$file" 2>/dev/null)"
+
+if [[ -n "$errors" ]]; then
+  echo "tasksList.json structure validation failed:" >&2
+  printf '%s\n' "$errors" >&2
+  exit 1
+fi
+
+duplicate_keys="$(jq -r '
+  [.[].taskKey] | group_by(.) | map(select(length > 1) | .[0]) | join(", ")
+' "$file" 2>/dev/null)"
+if [[ -n "$duplicate_keys" ]]; then
+  echo "tasksList.json has duplicate taskKey values: $duplicate_keys" >&2
+  exit 1
+fi
+
+count="$(jq 'length' "$file")"
+echo "tasksList.json is valid ($count task(s))"
+exit 0

--- a/.github/scripts/validate-translations.sh
+++ b/.github/scripts/validate-translations.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Validate the shape of app-configuration/translations/ inside a CAP root.
+#
+# Usage: validate-translations.sh <cap-root>
+#
+# Exit codes:
+#   0 - translations are valid (or directory is absent — it's optional)
+#   1 - translations are invalid (errors printed to stderr)
+#   2 - usage error (bad args or unreadable input)
+#
+# Schema:
+#   - Locale filenames must be in the supported set (kept in sync with the
+#     "Supported locales" table in CONTRIBUTING.md).
+#   - en-US.json is required when the directory exists.
+#   - Each locale file must be a JSON object with a "tasks" object whose
+#     entries each have non-empty "name" and "description" strings.
+#     Optional "adminComponents" object holds per-component "attributes"
+#     with non-empty "label" strings.
+#   - tasksList.json taskKeys must all appear in en-US.json's "tasks".
+#   - Non-default locales must have the same task key set as en-US.json.
+#   - When adminComponents.json is present, every (componentKey,
+#     attribute id) pair must appear in en-US.json's adminComponents and
+#     all non-default locales must match en-US.json's pair set exactly.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $(basename "$0") <cap-root>" >&2
+  exit 2
+fi
+
+cap_root="$1"
+
+if [[ ! -d "$cap_root" ]]; then
+  echo "CAP root not found: $cap_root" >&2
+  exit 2
+fi
+
+# Set of supported BM locales — must match the table in CONTRIBUTING.md
+# under "Localizing app-shipped strings > Supported locales".
+SUPPORTED_LOCALES=("ar_MA" "de" "en-US" "es" "fr" "it" "ja" "ko" "nl" "pl" "pt" "zh_CN" "zh_TW")
+
+translations_dir="$cap_root/app-configuration/translations"
+
+if [[ ! -d "$translations_dir" ]]; then
+  echo "No app-configuration/translations/ - OK (optional)"
+  exit 0
+fi
+
+default_locale="$translations_dir/en-US.json"
+if [[ ! -f "$default_locale" ]]; then
+  echo "app-configuration/translations/ exists but en-US.json is missing" >&2
+  exit 1
+fi
+
+# Validate per-file shape.
+shape_errors=""
+while IFS= read -r locale_file; do
+  if ! jq empty "$locale_file" 2>/dev/null; then
+    shape_errors+=$'\n'"$(basename "$locale_file"): not valid JSON"
+    continue
+  fi
+  if ! jq -e '.tasks | type == "object"' "$locale_file" >/dev/null 2>&1; then
+    shape_errors+=$'\n'"$(basename "$locale_file"): missing or non-object \"tasks\" key"
+    continue
+  fi
+  bad_entries="$(jq -r '
+    .tasks
+    | to_entries
+    | map(select(
+        (.value | type) != "object"
+        or (.value.name | type) != "string" or (.value.name | length) == 0
+        or (.value.description | type) != "string" or (.value.description | length) == 0
+      ) | .key)
+    | join(", ")
+  ' "$locale_file" 2>/dev/null)"
+  if [[ -n "$bad_entries" ]]; then
+    shape_errors+=$'\n'"$(basename "$locale_file"): tasks with missing/invalid name or description: $bad_entries"
+  fi
+
+  if jq -e 'has("adminComponents")' "$locale_file" >/dev/null 2>&1; then
+    if ! jq -e '.adminComponents | type == "object"' "$locale_file" >/dev/null 2>&1; then
+      shape_errors+=$'\n'"$(basename "$locale_file"): \"adminComponents\" must be an object"
+      continue
+    fi
+    bad_admin="$(jq -r '
+      .adminComponents
+      | to_entries
+      | map(
+          .key as $ck |
+          (.value | (
+            if type != "object" then "\($ck): must be an object"
+            elif has("attributes") | not then "\($ck): missing \"attributes\""
+            elif (.attributes | type) != "object" then "\($ck): \"attributes\" must be an object"
+            else
+              (.attributes | to_entries | map(
+                select(
+                  (.value | type) != "object"
+                  or (.value.label | type) != "string"
+                  or (.value.label | length) == 0
+                ) | "\($ck).attributes.\(.key): \"label\" missing or invalid"
+              ) | join("; "))
+            end
+          ))
+        )
+      | map(select(. != null and . != ""))
+      | join("; ")
+    ' "$locale_file" 2>/dev/null)"
+    if [[ -n "$bad_admin" ]]; then
+      shape_errors+=$'\n'"$(basename "$locale_file"): adminComponents shape invalid: $bad_admin"
+    fi
+  fi
+done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
+
+if [[ -n "$shape_errors" ]]; then
+  echo "app-configuration/translations/ shape validation failed:$shape_errors" >&2
+  exit 1
+fi
+
+# Locale filenames must be in the supported set.
+unsupported_locales=()
+while IFS= read -r locale_file; do
+  fname="$(basename "$locale_file" .json)"
+  ok=false
+  for supported in "${SUPPORTED_LOCALES[@]}"; do
+    [[ "$fname" == "$supported" ]] && ok=true && break
+  done
+  [[ "$ok" == "false" ]] && unsupported_locales+=("$fname")
+done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
+
+if [[ ${#unsupported_locales[@]} -gt 0 ]]; then
+  echo "Unsupported locale file(s) in app-configuration/translations/: ${unsupported_locales[*]} (supported: ${SUPPORTED_LOCALES[*]})" >&2
+  exit 1
+fi
+
+# tasksList.json taskKey coverage in en-US.json.
+tasks_list="$cap_root/app-configuration/tasksList.json"
+if [[ -f "$tasks_list" ]]; then
+  missing_in_en="$(jq -r --argjson en "$(jq '.tasks | keys' "$default_locale")" \
+    '[.[] | .taskKey] - $en | join(", ")' "$tasks_list" 2>/dev/null)"
+  if [[ -n "$missing_in_en" ]]; then
+    echo "tasksList.json references taskKey(s) not present in translations/en-US.json: $missing_in_en" >&2
+    exit 1
+  fi
+fi
+
+# Non-default locales must share en-US's task key set exactly.
+en_keys_sorted="$(jq -r '.tasks | keys_unsorted | sort | join(",")' "$default_locale")"
+while IFS= read -r locale_file; do
+  [[ "$locale_file" == "$default_locale" ]] && continue
+  locale_keys_sorted="$(jq -r '.tasks | keys_unsorted | sort | join(",")' "$locale_file")"
+  if [[ "$locale_keys_sorted" != "$en_keys_sorted" ]]; then
+    extra_in_locale="$(jq -r --argjson en "$(jq '.tasks | keys' "$default_locale")" \
+      '(.tasks | keys) - $en | join(", ")' "$locale_file")"
+    missing_in_locale="$(jq -r --argjson locale "$(jq '.tasks | keys' "$locale_file")" \
+      '(.tasks | keys) - $locale | join(", ")' "$default_locale")"
+    msg="$(basename "$locale_file") tasks key parity mismatch with en-US.json"
+    [[ -n "$missing_in_locale" ]] && msg+=" — missing: $missing_in_locale"
+    [[ -n "$extra_in_locale" ]] && msg+=" — extra: $extra_in_locale"
+    echo "$msg" >&2
+    exit 1
+  fi
+done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
+
+# adminComponents coverage + parity (only when adminComponents.json is shipped).
+admin_components="$cap_root/app-configuration/adminComponents.json"
+if [[ -f "$admin_components" ]]; then
+  cap_pairs_sorted="$(jq -r '
+    [.configuration // []
+      | .[]
+      | select(has("componentKey") and (.attributes | type) == "array")
+      | .componentKey as $ck
+      | .attributes[]
+      | "\($ck)/\(.id)"]
+    | sort | join(",")
+  ' "$admin_components")"
+
+  flatten_admin() {
+    local f="$1"
+    jq -r '
+      (.adminComponents // {})
+      | to_entries
+      | map(.key as $ck | (.value.attributes // {}) | keys | map("\($ck)/\(.)"))
+      | flatten | sort | join(",")
+    ' "$f"
+  }
+
+  en_admin_pairs="$(flatten_admin "$default_locale")"
+  missing_in_en_admin="$(comm -23 \
+    <(printf '%s\n' "$cap_pairs_sorted" | tr ',' '\n' | grep -v '^$') \
+    <(printf '%s\n' "$en_admin_pairs" | tr ',' '\n' | grep -v '^$') | tr '\n' ',' | sed 's/,$//')"
+  if [[ -n "$missing_in_en_admin" ]]; then
+    echo "adminComponents.json references componentKey/attribute pair(s) not present in translations/en-US.json: $missing_in_en_admin" >&2
+    exit 1
+  fi
+
+  while IFS= read -r locale_file; do
+    [[ "$locale_file" == "$default_locale" ]] && continue
+    locale_admin_pairs="$(flatten_admin "$locale_file")"
+    if [[ "$locale_admin_pairs" != "$en_admin_pairs" ]]; then
+      extra="$(comm -23 \
+        <(printf '%s\n' "$locale_admin_pairs" | tr ',' '\n' | grep -v '^$') \
+        <(printf '%s\n' "$en_admin_pairs" | tr ',' '\n' | grep -v '^$') | tr '\n' ',' | sed 's/,$//')"
+      missing="$(comm -23 \
+        <(printf '%s\n' "$en_admin_pairs" | tr ',' '\n' | grep -v '^$') \
+        <(printf '%s\n' "$locale_admin_pairs" | tr ',' '\n' | grep -v '^$') | tr '\n' ',' | sed 's/,$//')"
+      msg="$(basename "$locale_file") adminComponents key parity mismatch with en-US.json"
+      [[ -n "$missing" ]] && msg+=" — missing: $missing"
+      [[ -n "$extra" ]] && msg+=" — extra: $extra"
+      echo "$msg" >&2
+      exit 1
+    fi
+  done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
+fi
+
+locale_count="$(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')"
+echo "translations/ is valid ($locale_count locale file(s))"
+exit 0

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -163,68 +163,14 @@ jobs:
               exit 1
             fi
 
-            # Validate tasksList.json is valid JSON
-            if ! jq empty "$required_task_list" 2>/dev/null; then
-              echo "::error file=$zip_path::app-configuration/tasksList.json is not valid JSON"
+            # See .github/scripts/validate-tasks-list.sh for schema.
+            if ! tasks_output="$(bash ".github/scripts/validate-tasks-list.sh" "$required_task_list" 2>&1)"; then
+              echo "::error file=$zip_path::app-configuration/tasksList.json validation failed:"
+              printf '%s\n' "$tasks_output"
               rm -rf "$tmpdir"
               exit 1
             fi
-
-            # Must be a non-empty JSON array
-            if ! jq -e 'type == "array" and length > 0' "$required_task_list" >/dev/null 2>&1; then
-              echo "::error file=$zip_path::app-configuration/tasksList.json must be a non-empty JSON array"
-              rm -rf "$tmpdir"
-              exit 1
-            fi
-
-            # Validate each task object:
-            #   Required: taskKey (snake_case identifier, unique per file),
-            #             name (non-empty string), description (non-empty string),
-            #             taskNumber (string, sequential from "1")
-            #   Optional: link (string, may be empty)
-            validation_errors=$(jq -r '
-              [to_entries[] |
-               .key as $idx |
-               .value as $task |
-               (
-                 if ($task | type) != "object" then
-                   "Item at index \($idx): must be an object"
-                 elif ($task.taskKey | type) != "string" or ($task.taskKey | length) == 0 then
-                   "Item at index \($idx): \"taskKey\" is required and must be a non-empty string"
-                 elif ($task.taskKey | test("^[a-z][a-z0-9_]*$")) | not then
-                   "Item at index \($idx): \"taskKey\" must match ^[a-z][a-z0-9_]*$ (snake_case, got \"\($task.taskKey)\")"
-                 elif ($task.name | type) != "string" or ($task.name | length) == 0 then
-                   "Item at index \($idx): \"name\" is required and must be a non-empty string"
-                 elif ($task.description | type) != "string" or ($task.description | length) == 0 then
-                   "Item at index \($idx): \"description\" is required and must be a non-empty string"
-                 elif ($task.taskNumber | type) != "string" or ($task.taskNumber | length) == 0 then
-                   "Item at index \($idx): \"taskNumber\" is required and must be a non-empty string"
-                 elif $task.taskNumber != ($idx + 1 | tostring) then
-                   "Item at index \($idx): \"taskNumber\" must be \"\($idx + 1)\" (got \"\($task.taskNumber)\")"
-                 elif ($task | has("link")) and (($task.link | type) != "string") then
-                   "Item at index \($idx): \"link\" must be a string when present"
-                 else
-                   empty
-                 end
-               )] | join("\n")
-            ' "$required_task_list" 2>/dev/null)
-
-            if [[ -n "$validation_errors" ]]; then
-              echo "::error file=$zip_path::app-configuration/tasksList.json structure validation failed:"
-              echo "$validation_errors"
-              rm -rf "$tmpdir"
-              exit 1
-            fi
-
-            # taskKey uniqueness check (separate pass — easier to read than folding into the per-task validator)
-            duplicate_keys=$(jq -r '[.[].taskKey] | group_by(.) | map(select(length > 1) | .[0]) | join(", ")' "$required_task_list" 2>/dev/null)
-            if [[ -n "$duplicate_keys" ]]; then
-              echo "::error file=$zip_path::app-configuration/tasksList.json has duplicate taskKey values: $duplicate_keys"
-              rm -rf "$tmpdir"
-              exit 1
-            fi
-
-            echo "  ✓ tasksList.json is valid ($(jq 'length' "$required_task_list") task(s))"
+            echo "  ✓ $tasks_output"
 
             # Validate optional app-configuration/adminComponents.json.
             # See .github/scripts/validate-admin-components.sh for schema.
@@ -578,10 +524,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Set of supported BM locales — must match the table in CONTRIBUTING.md
-          # under "Localizing app-shipped strings > Supported locales".
-          supported_locales=("ar_MA" "de" "en-US" "es" "fr" "it" "ja" "ko" "nl" "pl" "pt" "zh_CN" "zh_TW")
-
           [[ -s changed_zips.txt ]] || exit 0
 
           while IFS= read -r zip_path; do
@@ -591,207 +533,15 @@ jobs:
             unzip -q "$zip_path" -d "$tmpdir"
 
             root="$(find "$tmpdir" -mindepth 1 -maxdepth 1 -type d -not -name '__MACOSX' -print -quit)"
-            translations_dir="$root/app-configuration/translations"
 
-            # Translations directory is optional. If absent, nothing to do.
-            if [[ ! -d "$translations_dir" ]]; then
-              echo "No app-configuration/translations/ for $(basename "$zip_path") - OK (optional)"
-              rm -rf "$tmpdir"
-              continue
-            fi
-
-            # en-US.json is required when the directory exists.
-            default_locale="$translations_dir/en-US.json"
-            if [[ ! -f "$default_locale" ]]; then
-              echo "::error file=$zip_path::app-configuration/translations/ exists but en-US.json is missing"
+            # See .github/scripts/validate-translations.sh for schema.
+            if ! translations_output="$(bash ".github/scripts/validate-translations.sh" "$root" 2>&1)"; then
+              echo "::error file=$zip_path::app-configuration/translations/ validation failed:"
+              printf '%s\n' "$translations_output"
               rm -rf "$tmpdir"
               exit 1
             fi
-
-            # Every locale file must be valid JSON with the expected shape:
-            #   {
-            #     "tasks": { "<taskKey>": { "name": "...", "description": "..." }, ... },
-            #     "adminComponents": {                              (optional)
-            #       "<componentKey>": {
-            #         "attributes": { "<id>": { "label": "..." }, ... }
-            #       }, ...
-            #     }
-            #   }
-            shape_errors=""
-            while IFS= read -r locale_file; do
-              if ! jq empty "$locale_file" 2>/dev/null; then
-                shape_errors+=$'\n'"$(basename "$locale_file"): not valid JSON"
-                continue
-              fi
-              if ! jq -e '.tasks | type == "object"' "$locale_file" >/dev/null 2>&1; then
-                shape_errors+=$'\n'"$(basename "$locale_file"): missing or non-object \"tasks\" key"
-                continue
-              fi
-              # Each task entry must have non-empty name and description strings.
-              bad_entries=$(jq -r '
-                .tasks
-                | to_entries
-                | map(select(
-                    (.value | type) != "object"
-                    or (.value.name | type) != "string" or (.value.name | length) == 0
-                    or (.value.description | type) != "string" or (.value.description | length) == 0
-                  ) | .key)
-                | join(", ")
-              ' "$locale_file" 2>/dev/null)
-              if [[ -n "$bad_entries" ]]; then
-                shape_errors+=$'\n'"$(basename "$locale_file"): tasks with missing/invalid name or description: $bad_entries"
-              fi
-              # adminComponents namespace is optional. When present, validate shape.
-              if jq -e 'has("adminComponents")' "$locale_file" >/dev/null 2>&1; then
-                if ! jq -e '.adminComponents | type == "object"' "$locale_file" >/dev/null 2>&1; then
-                  shape_errors+=$'\n'"$(basename "$locale_file"): \"adminComponents\" must be an object"
-                  continue
-                fi
-                bad_admin=$(jq -r '
-                  .adminComponents
-                  | to_entries
-                  | map(
-                      .key as $ck |
-                      (.value | (
-                        if type != "object" then "\($ck): must be an object"
-                        elif has("attributes") | not then "\($ck): missing \"attributes\""
-                        elif (.attributes | type) != "object" then "\($ck): \"attributes\" must be an object"
-                        else
-                          (.attributes | to_entries | map(
-                            select(
-                              (.value | type) != "object"
-                              or (.value.label | type) != "string"
-                              or (.value.label | length) == 0
-                            ) | "\($ck).attributes.\(.key): \"label\" missing or invalid"
-                          ) | join("; "))
-                        end
-                      ))
-                    )
-                  | map(select(. != null and . != ""))
-                  | join("; ")
-                ' "$locale_file" 2>/dev/null)
-                if [[ -n "$bad_admin" ]]; then
-                  shape_errors+=$'\n'"$(basename "$locale_file"): adminComponents shape invalid: $bad_admin"
-                fi
-              fi
-            done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
-
-            if [[ -n "$shape_errors" ]]; then
-              echo "::error file=$zip_path::app-configuration/translations/ shape validation failed:$shape_errors"
-              rm -rf "$tmpdir"
-              exit 1
-            fi
-
-            # Locale filenames must be in the supported set.
-            unsupported_locales=""
-            while IFS= read -r locale_file; do
-              fname="$(basename "$locale_file" .json)"
-              ok=false
-              for supported in "${supported_locales[@]}"; do
-                [[ "$fname" == "$supported" ]] && ok=true && break
-              done
-              [[ "$ok" == "false" ]] && unsupported_locales+="$fname "
-            done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
-
-            if [[ -n "$unsupported_locales" ]]; then
-              echo "::error file=$zip_path::Unsupported locale file(s) in app-configuration/translations/: $unsupported_locales(supported: ${supported_locales[*]})"
-              rm -rf "$tmpdir"
-              exit 1
-            fi
-
-            # Build the canonical key set from en-US.json.
-            en_keys_sorted=$(jq -r '.tasks | keys_unsorted | sort | join(",")' "$default_locale")
-
-            # Every taskKey in tasksList.json must be present in en-US.json.
-            tasks_list="$root/app-configuration/tasksList.json"
-            missing_in_en=$(jq -r --argjson en "$(jq '.tasks | keys' "$default_locale")" \
-              '[.[] | .taskKey] - $en | join(", ")' "$tasks_list" 2>/dev/null)
-            if [[ -n "$missing_in_en" ]]; then
-              echo "::error file=$zip_path::tasksList.json references taskKey(s) not present in translations/en-US.json: $missing_in_en"
-              rm -rf "$tmpdir"
-              exit 1
-            fi
-
-            # Every non-default locale file must reference exactly the same task keys as en-US.json.
-            while IFS= read -r locale_file; do
-              [[ "$locale_file" == "$default_locale" ]] && continue
-              locale_keys_sorted=$(jq -r '.tasks | keys_unsorted | sort | join(",")' "$locale_file")
-              if [[ "$locale_keys_sorted" != "$en_keys_sorted" ]]; then
-                # Compute set differences for a clearer error message.
-                extra_in_locale=$(jq -r --argjson en "$(jq '.tasks | keys' "$default_locale")" \
-                  '(.tasks | keys) - $en | join(", ")' "$locale_file")
-                missing_in_locale=$(jq -r --argjson locale "$(jq '.tasks | keys' "$locale_file")" \
-                  '(.tasks | keys) - $locale | join(", ")' "$default_locale")
-                msg="$(basename "$locale_file") tasks key parity mismatch with en-US.json"
-                [[ -n "$missing_in_locale" ]] && msg+=" — missing: $missing_in_locale"
-                [[ -n "$extra_in_locale" ]] && msg+=" — extra: $extra_in_locale"
-                echo "::error file=$zip_path::$msg"
-                rm -rf "$tmpdir"
-                exit 1
-              fi
-            done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
-
-            # adminComponents coverage + parity (only when adminComponents.json is shipped).
-            admin_components="$root/app-configuration/adminComponents.json"
-            if [[ -f "$admin_components" ]]; then
-              # Build the canonical (componentKey, attribute id) pairs from adminComponents.json
-              # configuration[]. Only configuration[] entries are required to declare componentKey
-              # in the current schema. Pairs are flattened to "componentKey/attribute_id" for set comparison.
-              cap_pairs_sorted=$(jq -r '
-                [.configuration // []
-                  | .[]
-                  | select(has("componentKey") and (.attributes | type) == "array")
-                  | .componentKey as $ck
-                  | .attributes[]
-                  | "\($ck)/\(.id)"]
-                | sort | join(",")
-              ' "$admin_components")
-
-              # Helper: flatten a locale file's adminComponents tree into the same pair shape.
-              flatten_admin() {
-                local file="$1"
-                jq -r '
-                  (.adminComponents // {})
-                  | to_entries
-                  | map(.key as $ck | (.value.attributes // {}) | keys | map("\($ck)/\(.)"))
-                  | flatten | sort | join(",")
-                ' "$file"
-              }
-
-              # Coverage: every CAP pair must exist in en-US.json's adminComponents.
-              en_admin_pairs=$(flatten_admin "$default_locale")
-              missing_in_en_admin=$(comm -23 \
-                <(printf '%s\n' "$cap_pairs_sorted" | tr ',' '\n' | grep -v '^$') \
-                <(printf '%s\n' "$en_admin_pairs" | tr ',' '\n' | grep -v '^$') | tr '\n' ',' | sed 's/,$//')
-              if [[ -n "$missing_in_en_admin" ]]; then
-                echo "::error file=$zip_path::adminComponents.json references componentKey/attribute pair(s) not present in translations/en-US.json: $missing_in_en_admin"
-                rm -rf "$tmpdir"
-                exit 1
-              fi
-
-              # Parity: every non-default locale's adminComponents pair set must equal en-US's.
-              while IFS= read -r locale_file; do
-                [[ "$locale_file" == "$default_locale" ]] && continue
-                locale_admin_pairs=$(flatten_admin "$locale_file")
-                if [[ "$locale_admin_pairs" != "$en_admin_pairs" ]]; then
-                  extra=$(comm -23 \
-                    <(printf '%s\n' "$locale_admin_pairs" | tr ',' '\n' | grep -v '^$') \
-                    <(printf '%s\n' "$en_admin_pairs" | tr ',' '\n' | grep -v '^$') | tr '\n' ',' | sed 's/,$//')
-                  missing=$(comm -23 \
-                    <(printf '%s\n' "$en_admin_pairs" | tr ',' '\n' | grep -v '^$') \
-                    <(printf '%s\n' "$locale_admin_pairs" | tr ',' '\n' | grep -v '^$') | tr '\n' ',' | sed 's/,$//')
-                  msg="$(basename "$locale_file") adminComponents key parity mismatch with en-US.json"
-                  [[ -n "$missing" ]] && msg+=" — missing: $missing"
-                  [[ -n "$extra" ]] && msg+=" — extra: $extra"
-                  echo "::error file=$zip_path::$msg"
-                  rm -rf "$tmpdir"
-                  exit 1
-                fi
-              done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
-            fi
-
-            locale_count=$(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')
-            echo "  ✓ translations/ validated ($locale_count locale file(s))"
+            echo "  ✓ $translations_output"
 
             rm -rf "$tmpdir"
           done < changed_zips.txt


### PR DESCRIPTION
Extract tasksList.json + translations validation into shared scripts

Move the inline jq blocks in verify-zip.yml Step 3 (tasksList.json) and Step 9 (app-configuration/translations/) into reusable shell scripts under .github/scripts/, matching the existing validate-admin-components.sh pattern. The /validate-app skill now invokes the same scripts so CI and local validation share a single source of truth.

- New: .github/scripts/validate-tasks-list.sh
- New: .github/scripts/validate-translations.sh
- New test suites mirror test-validate-admin-components.sh
- verify-zip.yml shrinks from 799 to 548 lines
- validate-app/SKILL.md Step 10b calls all three validators against the extracted CAP root; Step 11 clarified as the manifest-level translations check (a different file)
- Remove index.ts validation
- Directory vs. ZIP mode for /validate-app