### PR TITLE
@W-23544905: disable GUS WI auto-file until Connected App is IP-relaxed

### DIFF
--- a/.github/workflows/gus-security-review.yml
+++ b/.github/workflows/gus-security-review.yml
@@ -38,6 +38,12 @@ permissions:
 jobs:
   gus-security-review:
     runs-on: ubuntu-latest
+    # Temporarily disabled: the GUS Connected App backing GUS_SFDX_AUTH_URL
+    # enforces IP restrictions, so refresh-token auth from GitHub-hosted
+    # runners fails with "RefreshTokenAuthError: ip restricted". Re-enable
+    # by removing this `if:` once a Connected App with "Relax IP
+    # restrictions" is provisioned and the secret is rotated.
+    if: false
     steps:
       - name: Checkout base (trusted)
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- The `Authenticate to GUS via sfdx-url` step in `gus-security-review.yml` fails on every external CAP PR (e.g. [#52](https://github.com/SalesforceCommerceCloud/commerce-apps/pull/52), run `30073362504`) with `RefreshTokenAuthError: ip restricted`. The refresh token in `GUS_SFDX_AUTH_URL` is bound to a Connected App whose OAuth policy enforces IP restrictions, and GitHub-hosted runners are outside any Salesforce trusted-IP list.
- Gate the `gus-security-review` job on `if: false` so external PRs stop turning red. The Slack canary in `notify-slack-cap-pr.yml` still posts on every CAP PR, so operators keep a signal per submission.
- Re-enable by deleting the `if: false` once a Connected App with **Relax IP restrictions** is provisioned and `GUS_SFDX_AUTH_URL` is rotated to a token minted against it.

## Test plan
- [ ] Open (or re-run) a CAP PR from a fork — confirm the `GUS Security Review Auto-file` job is skipped instead of failing.
- [ ] Confirm the `Notify Slack of CAP PR` workflow still runs green and posts one message per PR.
- [ ] Once the new IP-relaxed Connected App is live, remove `if: false`, rotate `GUS_SFDX_AUTH_URL`, and verify a WI is filed on the next external new-app PR.