### PR TITLE
@W-23543664: Add forward-integration auto-promotion across release branches

### DIFF
--- a/.github/scripts/promotion-utils.sh
+++ b/.github/scripts/promotion-utils.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+
+# Helpers for forward-integration (auto-promotion) of app artifacts across
+# release branches. Promotion is forward-only along the chain
+#   release/<oldest> -> ... -> release/<newest> -> main
+# Each function is pure (reads args / files, writes stdout) so it can be unit
+# tested by test-promotion-utils.sh without a live checkout.
+
+# Prints the next branch in the forward-integration chain for a given ref, or
+# nothing when the ref is the end of the chain (main) or not a release branch.
+#
+#   next_release_branch <current_ref> <newline_separated_branch_list>
+#
+# Rules:
+#   - "main"            -> chain terminates, prints nothing.
+#   - "release/X.Y"     -> the smallest release/X'.Y' strictly greater than the
+#                          current version; if none exists, "main".
+#   - anything else     -> prints nothing (feature branches are not promoted).
+#
+# Version comparison is numeric on (major, minor); no dependency on `sort -V`
+# so the behavior is identical on the CI runner and on macOS.
+next_release_branch() {
+  local current="${1:?current ref is required}"
+  local branch_list="${2:-}"
+
+  if [[ "$current" == "main" ]]; then
+    return 0
+  fi
+  if [[ ! "$current" =~ ^(refs/heads/)?release/([0-9]+)\.([0-9]+)$ ]]; then
+    return 0
+  fi
+  local cmaj="${BASH_REMATCH[2]}" cmin="${BASH_REMATCH[3]}"
+
+  local best_maj="" best_min="" best=""
+  local line b maj min
+  while IFS= read -r line; do
+    b="${line#refs/heads/}"
+    [[ "$b" =~ ^release/([0-9]+)\.([0-9]+)$ ]] || continue
+    maj="${BASH_REMATCH[1]}"
+    min="${BASH_REMATCH[2]}"
+
+    # Keep only versions strictly greater than the current one.
+    if (( maj > cmaj || (maj == cmaj && min > cmin) )); then
+      # Track the smallest such version (the immediate next hop).
+      if [[ -z "$best" ]] || (( maj < best_maj || (maj == best_maj && min < best_min) )); then
+        best_maj="$maj"; best_min="$min"; best="release/$maj.$min"
+      fi
+    fi
+  done <<< "$branch_list"
+
+  if [[ -n "$best" ]]; then
+    echo "$best"
+  else
+    echo "main"
+  fi
+}
+
+# Merges a promoted (version, tag) into the target branch's catalog.json and
+# prints the merged JSON to stdout. Two invariants:
+#   - versions is a union: the (version, tag) pair is appended only when absent,
+#     so re-promoting the same artifact is idempotent.
+#   - latest is monotonic: it is recomputed as the highest semver across the
+#     merged versions, never blindly overwritten. Promoting an OLDER version
+#     forward (e.g. a back-port hop) therefore never regresses `latest` when the
+#     target already carries a newer version. A release ranks above a
+#     pre-release of the same major.minor.patch.
+#
+#   merge_catalog_json <target_catalog_path> <version> <tag>
+merge_catalog_json() {
+  local catalog_path="${1:?target catalog path is required}"
+  local version="${2:?version is required}"
+  local tag="${3:?tag is required}"
+
+  jq --arg v "$version" --arg t "$tag" '
+    # [major, minor, patch] as numbers; the pre-release suffix is dropped for
+    # the primary key and handled separately below.
+    def mmp($s): ($s | split("-")[0] | split(".") | map(tonumber));
+    # 1 for a release, 0 for a pre-release, so release > pre-release at equal MMP.
+    def rank($s): (if ($s | test("-")) then 0 else 1 end);
+
+    (.versions // []) as $existing
+    | (if any($existing[]; .version == $v and .tag == $t)
+         then $existing
+         else $existing + [{"version": $v, "tag": $t}]
+       end) as $merged
+    | {
+        "latest": ($merged | max_by([ mmp(.version), rank(.version) ])),
+        "versions": $merged
+      }
+  ' "$catalog_path"
+}
+
+# Upserts a manifest entry into a category array of the target branch's
+# manifest and prints the merged JSON. The manifest holds exactly one entry per
+# app, pinned to its latest version, keyed by `.id` (e.g. loqate carries nine
+# catalog versions but a single manifest entry). So the upsert:
+#   - matches the existing entry by `.id` (app identity), not by zip filename;
+#   - is monotonic on version: it replaces the entry only when the incoming
+#     version is >= the existing pinned version, so promoting an OLDER artifact
+#     forward (a back-port hop) never regresses the target's pinned version;
+#   - appends when the app is not yet present on the target;
+#   - creates the category array when the target manifest lacks it.
+# A release ranks above a pre-release of the same major.minor.patch.
+#
+#   merge_manifest_entry <target_manifest_path> <entry_json> <category>
+merge_manifest_entry() {
+  local manifest_path="${1:?target manifest path is required}"
+  local entry_json="${2:?entry JSON is required}"
+  local category="${3:?category is required}"
+
+  jq --argjson entry "$entry_json" --arg cat "$category" '
+    def mmp($s): ($s | split("-")[0] | split(".") | map(tonumber));
+    def rank($s): (if ($s | test("-")) then 0 else 1 end);
+    # Compare two semver strings: 1 if a>b, 0 if equal, -1 if a<b.
+    def semver_cmp($a; $b):
+      ([mmp($a), rank($a)]) as $ka | ([mmp($b), rank($b)]) as $kb
+      | if $ka > $kb then 1 elif $ka < $kb then -1 else 0 end;
+
+    ($entry.id) as $id
+    | (.[$cat] // []) as $arr
+    | ($arr | map(select((.id? // "") == $id)) | first) as $existing
+    | if $existing == null then
+        # New app on this target -> append.
+        .[$cat] = ($arr + [$entry])
+      elif (semver_cmp($entry.version; ($existing.version // "0.0.0")) >= 0) then
+        # Incoming version is newer or equal -> replace the pinned entry.
+        .[$cat] = ((($arr | map(select((.id? // "") != $id)))) + [$entry])
+      else
+        # Target already pins a newer version -> leave it untouched (monotonic).
+        .
+      end
+  ' "$manifest_path"
+}

--- a/.github/scripts/root-manifest-utils.sh
+++ b/.github/scripts/root-manifest-utils.sh
@@ -72,12 +72,53 @@ get_manifest_entry_for_zip() {
   match_count="$(jq 'length' <<< "$matches")"
 
   if [[ "$match_count" -eq 0 ]]; then
-    echo "::error file=$manifest_path::No manifest entry found for ZIP $zip_file"
+    # stderr so the annotation survives when a caller captures stdout via $(...)
+    echo "::error file=$manifest_path::No manifest entry found for ZIP $zip_file" >&2
     return 1
   fi
   if [[ "$match_count" -gt 1 ]]; then
-    echo "::error file=$manifest_path::Multiple manifest entries found for ZIP $zip_file"
+    echo "::error file=$manifest_path::Multiple manifest entries found for ZIP $zip_file" >&2
     return 1
+  fi
+
+  jq -c '.[0]' <<< "$matches"
+}
+
+# Prints the single matching manifest entry JSON object for a zip filename, or
+# nothing (empty stdout, exit 0) when the manifest has no entry for it.
+#
+# Unlike get_manifest_entry_for_zip, an absent entry is NOT an error: on a
+# forward-integration branch the monotonic manifest guard deliberately leaves a
+# back-ported (older) ZIP unreferenced - the branch's manifest stays pinned to
+# the newer version. Such a ZIP has no version/sha256 contract on this branch
+# and is not installable here, so the catalog/promotion jobs skip it rather
+# than failing. Ambiguous duplicates remain a hard error (return 1).
+lookup_manifest_entry_for_zip() {
+  local zip_file="${1:?zip filename is required}"
+  local manifest_path="${2:?manifest path is required}"
+
+  local matches
+  matches="$(
+    jq -c --arg z "$zip_file" '
+      [
+        to_entries[]
+        | select(.value | type == "array")
+        | .value[]?
+        | select(type == "object" and (.zip? == $z))
+      ]
+    ' "$manifest_path"
+  )"
+
+  local match_count
+  match_count="$(jq 'length' <<< "$matches")"
+
+  if [[ "$match_count" -gt 1 ]]; then
+    # stderr so the annotation survives when a caller captures stdout via $(...)
+    echo "::error file=$manifest_path::Multiple manifest entries found for ZIP $zip_file" >&2
+    return 1
+  fi
+  if [[ "$match_count" -eq 0 ]]; then
+    return 0
   fi
 
   jq -c '.[0]' <<< "$matches"

--- a/.github/scripts/test-promotion-utils.sh
+++ b/.github/scripts/test-promotion-utils.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/promotion-utils.sh"
+source "$SCRIPT_DIR/root-manifest-utils.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=""
+cleanup() { [[ -n "$TMPDIR_ROOT" ]] && rm -rf "$TMPDIR_ROOT"; }
+trap cleanup EXIT
+TMPDIR_ROOT="$(mktemp -d)"
+
+assert_eq() {
+  local desc="$1" expected="$2"; shift 2
+  local actual
+  actual="$("$@" 2>/dev/null)" || { echo "  FAIL: $desc (command failed)"; FAIL=$((FAIL + 1)); return; }
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_json_eq() {
+  local desc="$1" expected="$2"; shift 2
+  local actual
+  actual="$("$@" 2>/dev/null)" || { echo "  FAIL: $desc (command failed)"; FAIL=$((FAIL + 1)); return; }
+  # Compare canonicalized JSON so key order / whitespace do not matter.
+  local en an
+  en="$(jq -S . <<< "$expected")"
+  an="$(jq -S . <<< "$actual")"
+  if [[ "$en" == "$an" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "    expected: $en"
+    echo "    actual:   $an"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_fails() {
+  local desc="$1"; shift
+  if "$@" >/dev/null 2>&1; then
+    echo "  FAIL: $desc (expected non-zero exit, got success)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  fi
+}
+
+_FC=0
+mkfile() {
+  _FC=$((_FC + 1))
+  local f="$TMPDIR_ROOT/file_${_FC}.json"
+  printf '%s\n' "$1" > "$f"
+  printf '%s' "$f"
+}
+
+BRANCHES="$(printf '%s\n' \
+  refs/heads/main \
+  refs/heads/release/26.8 \
+  refs/heads/release/26.9 \
+  refs/heads/release/27.0 \
+  refs/heads/shaurye/feature-x \
+  refs/heads/CI/update-catalog-123)"
+
+echo "=== promotion-utils.sh tests ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# next_release_branch
+# ---------------------------------------------------------------------------
+echo "--- next_release_branch ---"
+
+assert_eq "26.8 -> 26.9"                 "release/26.9" next_release_branch "release/26.8" "$BRANCHES"
+assert_eq "26.9 -> 27.0"                 "release/27.0" next_release_branch "release/26.9" "$BRANCHES"
+assert_eq "highest release -> main"      "main"         next_release_branch "release/27.0" "$BRANCHES"
+assert_eq "refs/heads/ prefix accepted"  "release/26.9" next_release_branch "refs/heads/release/26.8" "$BRANCHES"
+assert_eq "major rollover picks minimal" "release/27.0" next_release_branch "release/26.9" \
+  "$(printf '%s\n' refs/heads/release/27.5 refs/heads/release/27.0 refs/heads/release/28.0)"
+assert_eq "unlisted current -> next existing" "release/26.8" next_release_branch "release/26.7" "$BRANCHES"
+
+# Terminal / non-participating refs print nothing.
+assert_eq "main terminates"              "" next_release_branch "main" "$BRANCHES"
+assert_eq "feature branch ignored"       "" next_release_branch "shaurye/feature-x" "$BRANCHES"
+assert_eq "CI branch ignored"            "" next_release_branch "CI/update-catalog-123" "$BRANCHES"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# merge_catalog_json
+# ---------------------------------------------------------------------------
+echo "--- merge_catalog_json ---"
+
+# Append a newer version -> latest advances.
+c1="$(mkfile '{"latest":{"version":"1.0.0","tag":"app-v1.0.0"},"versions":[{"version":"1.0.0","tag":"app-v1.0.0"}]}')"
+assert_json_eq "appends new version, advances latest" \
+  '{"latest":{"version":"1.1.0","tag":"app-v1.1.0"},"versions":[{"version":"1.0.0","tag":"app-v1.0.0"},{"version":"1.1.0","tag":"app-v1.1.0"}]}' \
+  merge_catalog_json "$c1" "1.1.0" "app-v1.1.0"
+
+# Re-promote same pair -> idempotent, no duplicate.
+c2="$(mkfile '{"latest":{"version":"1.1.0","tag":"app-v1.1.0"},"versions":[{"version":"1.0.0","tag":"app-v1.0.0"},{"version":"1.1.0","tag":"app-v1.1.0"}]}')"
+assert_json_eq "idempotent re-promote (no dup)" \
+  '{"latest":{"version":"1.1.0","tag":"app-v1.1.0"},"versions":[{"version":"1.0.0","tag":"app-v1.0.0"},{"version":"1.1.0","tag":"app-v1.1.0"}]}' \
+  merge_catalog_json "$c2" "1.1.0" "app-v1.1.0"
+
+# Promote an OLDER version forward into a branch that already has a newer one
+# -> version is unioned in, but latest must NOT regress (monotonic).
+c3="$(mkfile '{"latest":{"version":"2.0.0","tag":"app-v2.0.0"},"versions":[{"version":"2.0.0","tag":"app-v2.0.0"}]}')"
+assert_json_eq "older version does not regress latest" \
+  '{"latest":{"version":"2.0.0","tag":"app-v2.0.0"},"versions":[{"version":"2.0.0","tag":"app-v2.0.0"},{"version":"1.5.0","tag":"app-v1.5.0"}]}' \
+  merge_catalog_json "$c3" "1.5.0" "app-v1.5.0"
+
+# Patch-level ordering is numeric (10 > 9), not lexicographic.
+c4="$(mkfile '{"latest":{"version":"1.0.9","tag":"app-v1.0.9"},"versions":[{"version":"1.0.9","tag":"app-v1.0.9"}]}')"
+assert_json_eq "numeric patch ordering (1.0.10 > 1.0.9)" \
+  '{"latest":{"version":"1.0.10","tag":"app-v1.0.10"},"versions":[{"version":"1.0.9","tag":"app-v1.0.9"},{"version":"1.0.10","tag":"app-v1.0.10"}]}' \
+  merge_catalog_json "$c4" "1.0.10" "app-v1.0.10"
+
+# A release outranks a pre-release of the same MMP.
+c5="$(mkfile '{"latest":{"version":"1.2.0-rc.1","tag":"app-v1.2.0-rc.1"},"versions":[{"version":"1.2.0-rc.1","tag":"app-v1.2.0-rc.1"}]}')"
+assert_json_eq "release outranks equal pre-release" \
+  '{"latest":{"version":"1.2.0","tag":"app-v1.2.0"},"versions":[{"version":"1.2.0-rc.1","tag":"app-v1.2.0-rc.1"},{"version":"1.2.0","tag":"app-v1.2.0"}]}' \
+  merge_catalog_json "$c5" "1.2.0" "app-v1.2.0"
+
+# Missing versions array is tolerated (treated as empty).
+c6="$(mkfile '{}')"
+assert_json_eq "empty catalog seeds first entry" \
+  '{"latest":{"version":"1.0.0","tag":"app-v1.0.0"},"versions":[{"version":"1.0.0","tag":"app-v1.0.0"}]}' \
+  merge_catalog_json "$c6" "1.0.0" "app-v1.0.0"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# merge_manifest_entry
+# ---------------------------------------------------------------------------
+echo "--- merge_manifest_entry ---"
+
+# Different app id -> append (one entry per app coexists).
+m1="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}')"
+assert_json_eq "appends new app to category" \
+  '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"},{"id":"b","zip":"b-v1.0.0.zip","version":"1.0.0"}]}' \
+  merge_manifest_entry "$m1" '{"id":"b","zip":"b-v1.0.0.zip","version":"1.0.0"}' "shipping"
+
+# Same app id, newer version -> replace the single pinned entry (no dup, zip advances).
+m2="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}')"
+assert_json_eq "replaces pinned entry with newer version" \
+  '{"shipping":[{"id":"a","zip":"a-v1.1.0.zip","version":"1.1.0"}]}' \
+  merge_manifest_entry "$m2" '{"id":"a","zip":"a-v1.1.0.zip","version":"1.1.0"}' "shipping"
+
+# Same app id, same version -> idempotent replace (metadata may update, no dup).
+m2b="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0","sha256":"old"}]}')"
+assert_json_eq "idempotent upsert at equal version" \
+  '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0","sha256":"new"}]}' \
+  merge_manifest_entry "$m2b" '{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0","sha256":"new"}' "shipping"
+
+# Same app id, OLDER version (back-port hop) -> target's newer pin is untouched.
+m2c="$(mkfile '{"shipping":[{"id":"a","zip":"a-v2.0.0.zip","version":"2.0.0"}]}')"
+assert_json_eq "older version does not regress pinned entry" \
+  '{"shipping":[{"id":"a","zip":"a-v2.0.0.zip","version":"2.0.0"}]}' \
+  merge_manifest_entry "$m2c" '{"id":"a","zip":"a-v1.5.0.zip","version":"1.5.0"}' "shipping"
+
+# New category is created on the target when absent.
+m3="$(mkfile '{"defaultLocale":"en","tax":[{"id":"t","zip":"t-v1.0.0.zip","version":"1.0.0"}]}')"
+assert_json_eq "creates missing category" \
+  '{"defaultLocale":"en","tax":[{"id":"t","zip":"t-v1.0.0.zip","version":"1.0.0"}],"analytics":[{"id":"n","zip":"n-v1.0.0.zip","version":"1.0.0"}]}' \
+  merge_manifest_entry "$m3" '{"id":"n","zip":"n-v1.0.0.zip","version":"1.0.0"}' "analytics"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# lookup_manifest_entry_for_zip (tolerant lookup used by catalog/promotion jobs)
+# ---------------------------------------------------------------------------
+echo "--- lookup_manifest_entry_for_zip ---"
+
+# Present entry -> returned verbatim.
+lk1="$(mkfile '{"analytics":[{"id":"a","zip":"a-v1.0.2.zip","version":"1.0.2"}]}')"
+assert_json_eq "returns entry when present" \
+  '{"id":"a","zip":"a-v1.0.2.zip","version":"1.0.2"}' \
+  lookup_manifest_entry_for_zip "a-v1.0.2.zip" "$lk1"
+
+# Back-ported ZIP with no matching entry (manifest pinned to newer version)
+# -> empty stdout, exit 0 (the skip signal the workflow relies on).
+lk2="$(mkfile '{"analytics":[{"id":"a","zip":"a-v1.0.2.zip","version":"1.0.2"}]}')"
+assert_eq "missing entry -> empty (no error)" \
+  "" \
+  lookup_manifest_entry_for_zip "a-v1.0.0.zip" "$lk2"
+
+# Ambiguous duplicate zip across entries -> hard error (still fails).
+lk3="$(mkfile '{"analytics":[{"id":"a","zip":"dup.zip","version":"1.0.0"}],"tax":[{"id":"b","zip":"dup.zip","version":"2.0.0"}]}')"
+assert_fails "duplicate zip -> error" \
+  lookup_manifest_entry_for_zip "dup.zip" "$lk3"
+
+# Regression lock for the actual bug: capturing an absent entry via $(...) under
+# `set -euo pipefail` must NOT abort (empty stdout + exit 0), so the workflow's
+# skip branch can fire. This mirrors the exact call-site pattern.
+lk4="$(mkfile '{"analytics":[{"id":"a","zip":"a-v1.0.2.zip","version":"1.0.2"}]}')"
+if (
+  set -euo pipefail
+  source "$SCRIPT_DIR/root-manifest-utils.sh"
+  entry="$(lookup_manifest_entry_for_zip "a-v1.0.0.zip" "$lk4")"
+  [[ -z "$entry" ]]
+); then
+  echo "  PASS: absent entry under set -e -> no abort, empty capture"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: absent entry under set -e -> unexpected abort or non-empty"
+  FAIL=$((FAIL + 1))
+fi
+
+# Duplicate error annotation goes to stderr (survives $(...) stdout capture).
+lk5="$(mkfile '{"analytics":[{"id":"a","zip":"dup.zip","version":"1.0.0"}],"tax":[{"id":"b","zip":"dup.zip","version":"2.0.0"}]}')"
+dup_err="$(lookup_manifest_entry_for_zip "dup.zip" "$lk5" 2>&1 >/dev/null || true)"
+if [[ "$dup_err" == *"Multiple manifest entries"* ]]; then
+  echo "  PASS: duplicate error emitted on stderr"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: duplicate error not on stderr"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -2,7 +2,9 @@ name: Update Catalog.json w New App Version PR
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/**'
     paths:
       - '**/*.zip'
 
@@ -15,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout main
+      - name: Checkout pushed branch
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -28,10 +30,11 @@ jobs:
         run: |
           set -euo pipefail
           source ".github/scripts/root-manifest-utils.sh"
+          source ".github/scripts/promotion-utils.sh"
           manifest_path="commerce-apps-manifest/manifest.json"
           validate_manifest "$manifest_path"
 
-          # 1) Find ZIP files changed in this push to main (merge commit)
+          # 1) Find ZIP files changed in this push to the target branch (merge commit)
           mapfile -t changed_zips < <(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- '**/*.zip')
 
           if [[ ${#changed_zips[@]} -eq 0 ]]; then
@@ -63,7 +66,17 @@ jobs:
             fi
 
             zip_file="$(basename "$zip_path")"
-            entry="$(get_manifest_entry_for_zip "$zip_file" "$manifest_path")"
+            entry="$(lookup_manifest_entry_for_zip "$zip_file" "$manifest_path")"
+
+            # No manifest entry: this is a back-ported (older) ZIP that the
+            # monotonic manifest guard deliberately left unreferenced on this
+            # branch - the manifest stays pinned to the newer version. It has no
+            # version/sha256 contract here and nothing installs it, so skip it
+            # (the newer version already carries this branch's catalog/tag).
+            if [[ -z "$entry" ]]; then
+              echo "No manifest entry for $zip_file on this branch; skipping (back-ported/unpinned artifact)."
+              continue
+            fi
 
             # Version from manifest entry (expects .version)
             version="$(jq -r '.version // empty' <<< "$entry")"
@@ -75,21 +88,28 @@ jobs:
             # 3) Tag name = zip filename without .zip
             tag_name="${zip_file%.zip}"
 
-            # Create + push tag (skip if already exists)
-            if ! git rev-parse -q --verify "refs/tags/$tag_name" >/dev/null; then
+            # Tags are immutable and shared across branches: a given app version
+            # maps to exactly one artifact, so the tag is created once and never
+            # moved. The remote is the source of truth (the CI checkout is shallow
+            # per branch and may not have the tag locally). If it already exists on
+            # the remote, this is a promotion of an already-published version -
+            # leave the tag pinned to its original commit.
+            if git ls-remote --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1; then
+              echo "Tag $tag_name already exists on remote; leaving it pinned (immutable, shared)."
+            else
               git tag -a "$tag_name" -m "Release $tag_name"
-            fi
-            if ! git ls-remote --exit-code --tags origin "refs/tags/$tag_name" >/dev/null 2>&1; then
               git push origin "refs/tags/$tag_name"
             fi
 
-            # 4) Update latest and 5) Append a new versions entry
+            # 4) Merge this version/tag into catalog.json (shared helper).
+            # versions is a union (idempotent: re-publishing the same ZIP does
+            # not duplicate entries), and latest is recomputed monotonically as
+            # the highest semver across the merged versions - so this job stays
+            # consistent with the promotion job and never regresses latest when
+            # an older version is (re)published on a branch that already carries
+            # a newer one.
             tmp="$(mktemp)"
-            jq --arg v "$version" --arg t "$tag_name" '
-              .versions = (.versions // []) |
-              .latest = {"version": $v, "tag": $t} |
-              .versions = (.versions + [{"version": $v, "tag": $t}])
-            ' "$catalog_path" > "$tmp"
+            merge_catalog_json "$catalog_path" "$version" "$tag_name" > "$tmp"
 
             mv "$tmp" "$catalog_path"
             git add "$catalog_path"
@@ -155,12 +175,13 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          branch: CI/update-catalog-${{ github.run_id }}
+          base: ${{ github.ref_name }}
+          branch: CI/update-catalog-${{ github.ref_name }}-${{ github.run_id }}
           delete-branch: true
           commit-message: "CI: update catalog.json after ZIP merge"
-          title: "CI: update catalog.json after ZIP merge"
+          title: "CI: update catalog.json after ZIP merge into ${{ github.ref_name }}"
           body: |
-            This PR was auto-generated after a ZIP file was merged into `main`.
+            This PR was auto-generated after a ZIP file was merged into `${{ github.ref_name }}`.
 
             - Creates a tag matching the ZIP filename (without `.zip`)
             - Updates `catalog.json` `latest`
@@ -168,3 +189,221 @@ jobs:
             - Extracts and adds app icons to `commerce-apps-manifest/icons/`
           labels: |
             automation
+
+  # ---------------------------------------------------------------------------
+  # Forward-integration (auto-promotion).
+  #
+  # When a ZIP lands on a release branch, open a self-contained promotion PR
+  # into the next branch in the chain
+  #   release/<older> -> release/<newer> -> main
+  # carrying the ZIP, its manifest entry, the merged catalog.json, and icons.
+  #
+  # Because the PR carries a ZIP, merging it re-fires THIS workflow on the next
+  # branch, which advances the chain one hop further. The chain is therefore
+  # self-propagating with one gated (human/App-reviewed) merge per hop and no
+  # cross-workflow wiring. The `update-catalog-pr` job on the next branch sees
+  # no diff (catalog merge is idempotent, tag is immutable) and is a no-op.
+  #
+  # Runs only on release branches; `main` is the end of the chain.
+  # ---------------------------------------------------------------------------
+  promote-forward:
+    runs-on: ubuntu-latest
+    # Run after the catalog job so the immutable tag for this version is already
+    # pushed before the promotion PR (which references that tag) is opened.
+    needs: update-catalog-pr
+    if: ${{ startsWith(github.ref_name, 'release/') }}
+
+    steps:
+      - name: Checkout pushed branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Prepare promotion onto the next branch
+        id: prepare
+        shell: bash
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+          SOURCE_REF: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          source ".github/scripts/root-manifest-utils.sh"
+          source ".github/scripts/promotion-utils.sh"
+          manifest_path="commerce-apps-manifest/manifest.json"
+          validate_manifest "$manifest_path"
+
+          # 1) ZIPs changed by this push (the merge commit on the source branch).
+          #    On branch creation github.event.before is all-zeros and there is
+          #    no real "before" commit to diff against; skip rather than promote
+          #    a whole branch's worth of artifacts on its first push.
+          if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
+            echo "Branch-creation push (no prior commit); nothing to promote."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mapfile -t changed_zips < <(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- '**/*.zip')
+          if [[ ${#changed_zips[@]} -eq 0 ]]; then
+            echo "No .zip files changed. Nothing to promote."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 2) Determine the next hop from the live remote branch list. Fail loud
+          #    if the remote returned nothing: an empty list would make
+          #    next_release_branch fall through to "main" and skip release hops.
+          branch_list="$(git ls-remote --heads origin | awk '{print $2}')"
+          if [[ -z "$branch_list" ]]; then
+            echo "::error::git ls-remote returned no branches; cannot determine next hop"
+            exit 1
+          fi
+          next="$(next_release_branch "$SOURCE_REF" "$branch_list")"
+          if [[ -z "$next" ]]; then
+            echo "No forward hop from $SOURCE_REF; chain terminates."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Promoting $SOURCE_REF -> $next"
+
+          # 3) Stash source artifacts (ZIP bytes + source manifest) BEFORE we
+          #    switch to the target working tree.
+          stash="$RUNNER_TEMP/promote"
+          rm -rf "$stash"; mkdir -p "$stash"
+          cp "$manifest_path" "$stash/source-manifest.json"
+          : > "$stash/items.tsv"
+
+          for zip_path in "${changed_zips[@]}"; do
+            [[ -f "$zip_path" ]] || continue   # skip deletions
+            zip_file="$(basename "$zip_path")"
+            entry="$(lookup_manifest_entry_for_zip "$zip_file" "$stash/source-manifest.json")"
+
+            # No manifest entry on the source branch: a back-ported (older) ZIP
+            # the monotonic guard left unreferenced. It is not the pinned
+            # artifact here and the newer version already cascaded forward on its
+            # own, so do not carry it to the next branch.
+            if [[ -z "$entry" ]]; then
+              echo "No manifest entry for $zip_file on $SOURCE_REF; not promoting (back-ported/unpinned artifact)."
+              continue
+            fi
+
+            version="$(jq -r '.version // empty' <<< "$entry")"
+            category="$(jq -r --arg z "$zip_file" '
+              to_entries[]
+              | select(.value | type == "array")
+              | select(any(.value[]?; .zip? == $z))
+              | .key
+            ' "$stash/source-manifest.json")"
+            if [[ -z "$version" || "$version" == "null" || -z "$category" ]]; then
+              echo "::error file=$manifest_path::Missing version/category for ZIP $zip_file"
+              exit 1
+            fi
+            mkdir -p "$stash/zips/$(dirname "$zip_path")"
+            cp "$zip_path" "$stash/zips/$zip_path"
+            printf '%s\t%s\t%s\n' "$zip_path" "$version" "$category" >> "$stash/items.tsv"
+          done
+
+          if [[ ! -s "$stash/items.tsv" ]]; then
+            echo "No promotable ZIPs (all deletions). Nothing to promote."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 4) Switch to the target branch working tree.
+          git fetch origin "+refs/heads/$next:refs/remotes/origin/$next"
+          git checkout -B promote-work "origin/$next"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          icons_manifest_dir="commerce-apps-manifest/icons"
+          mkdir -p "$icons_manifest_dir"
+
+          # 5) Apply each stashed artifact onto the target branch.
+          while IFS=$'\t' read -r zip_path version category; do
+            [[ -z "$zip_path" ]] && continue
+            zip_file="$(basename "$zip_path")"
+            tag_name="${zip_file%.zip}"
+            entry="$(get_manifest_entry_for_zip "$zip_file" "$stash/source-manifest.json")"
+
+            # 5a) ZIP bytes (creates the app directory on the target if new).
+            mkdir -p "$(dirname "$zip_path")"
+            cp "$stash/zips/$zip_path" "$zip_path"
+            git add "$zip_path"
+
+            # 5b) Manifest entry (monotonic upsert keyed by app id).
+            tmp="$(mktemp)"
+            merge_manifest_entry "$manifest_path" "$entry" "$category" > "$tmp"
+            mv "$tmp" "$manifest_path"
+            git add "$manifest_path"
+
+            # 5c) catalog.json next to the ZIP (union versions, monotonic latest).
+            #     Seed an empty catalog for a brand-new app on the target.
+            catalog_path="$(dirname "$zip_path")/catalog.json"
+            [[ -f "$catalog_path" ]] || echo '{}' > "$catalog_path"
+            tmp="$(mktemp)"
+            merge_catalog_json "$catalog_path" "$version" "$tag_name" > "$tmp"
+            mv "$tmp" "$catalog_path"
+            git add "$catalog_path"
+
+            # 5d) Icons: copy from the ZIP into the shared icons dir.
+            isv_name="$(echo "$zip_path" | cut -d'/' -f2)"
+            if [[ -n "$isv_name" ]]; then
+              tmpdir="$(mktemp -d)"
+              unzip -q "$zip_path" -d "$tmpdir"
+              icons_dir="$(find "$tmpdir" -type d -name icons -print -quit)"
+              if [[ -n "$icons_dir" && -d "$icons_dir" ]]; then
+                mapfile -t icon_files < <(find "$icons_dir" -type f \( -iname "*.png" -o -iname "*.svg" -o -iname "*.jpg" -o -iname "*.jpeg" \) -print)
+                for icon_file in "${icon_files[@]}"; do
+                  dest_icon="$icons_manifest_dir/$(basename "$icon_file")"
+                  if [[ ! -f "$dest_icon" ]] || ! cmp -s "$icon_file" "$dest_icon"; then
+                    cp "$icon_file" "$dest_icon"
+                    git add "$dest_icon"
+                  fi
+                done
+              fi
+              rm -rf "$tmpdir"
+            fi
+          done < "$stash/items.tsv"
+
+          if git diff --cached --quiet; then
+            echo "Target $next already carries these artifacts. Nothing to promote."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # 6) Emit outputs for the PR step (slugs avoid slashes in the PR branch).
+          next_slug="${next//\//-}"
+          src_slug="${SOURCE_REF//\//-}"
+          {
+            echo "promote=true"
+            echo "next_branch=$next"
+            echo "pr_branch=CI/promote-${src_slug}-to-${next_slug}-${RUN_ID}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create forward-promotion PR
+        if: ${{ steps.prepare.outputs.promote == 'true' }}
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          base: ${{ steps.prepare.outputs.next_branch }}
+          branch: ${{ steps.prepare.outputs.pr_branch }}
+          delete-branch: true
+          commit-message: "CI: promote app artifacts from ${{ github.ref_name }} to ${{ steps.prepare.outputs.next_branch }}"
+          title: "CI: promote from ${{ github.ref_name }} → ${{ steps.prepare.outputs.next_branch }}"
+          body: |
+            Forward-integration PR auto-generated after a ZIP merged into `${{ github.ref_name }}`.
+
+            Carries the promoted artifacts, already merged, into `${{ steps.prepare.outputs.next_branch }}`:
+
+            - The app ZIP(s)
+            - The matching `commerce-apps-manifest/manifest.json` entry (monotonic upsert keyed by app id)
+            - The merged `catalog.json` (union `versions`, monotonic `latest`)
+            - Any app icons under `commerce-apps-manifest/icons/`
+
+            Merging this PR re-triggers the catalog workflow on `${{ steps.prepare.outputs.next_branch }}`,
+            which promotes forward to the next branch in the chain. Tags are immutable and shared,
+            so version-pinned installs stay stable across branches.
+          labels: |
+            automation
+            promotion


### PR DESCRIPTION
## Summary

Introduces forward-integration (auto-promotion) of app artifacts across release branches, ported from the `registry-testing` fork where it was validated end-to-end. When a ZIP lands on a release branch, a self-contained promotion PR is opened into the next branch in the chain (`release/<older>` → `release/<newer>` → `main`), carrying the ZIP, its manifest entry, the merged `catalog.json`, and icons. Because the PR carries a ZIP, merging it re-fires this workflow one hop further — the chain self-propagates with one gated merge per hop.

## Changes

- **`.github/scripts/promotion-utils.sh`** (new) — pure, unit-tested helpers: `next_release_branch`, `merge_catalog_json` (union versions, monotonic `latest`), `merge_manifest_entry` (monotonic upsert keyed by app id).
- **`.github/scripts/test-promotion-utils.sh`** (new) — 25 unit tests, auto-discovered by `run-all-tests.sh`.
- **`.github/scripts/root-manifest-utils.sh`** — adds tolerant `lookup_manifest_entry_for_zip` (empty stdout + exit 0 when a back-ported ZIP is deliberately unreferenced) and routes `::error::` annotations to stderr so they survive `$(...)` capture.
- **`.github/workflows/update-catalog.yml`** — triggers on `release/**` in addition to `main`; adds the `promote-forward` job; `update-catalog-pr` now skips unreferenced back-ported ZIPs instead of crashing under `set -euo pipefail`.

Full suite passes locally: `run-all-tests.sh` → 7 suites, 0 failed; promotion suite 25/25.


🤖 Generated with [Claude Code](https://claude.com/claude-code)