### PR TITLE
@W-23543664: Port remaining main-only changes into release/26.8

### DIFF
--- a/.claude/skills/shared/security-rules.md
+++ b/.claude/skills/shared/security-rules.md
@@ -28,10 +28,13 @@ Must fix before packaging or submission:
 - Q6: Absolute file paths in code
 - Q7: Console logging in cartridge code — use dw.system.Logger
 
-## Warning findings (3 checks — review recommended)
+## Warning findings (6 checks — review recommended)
 
 Should fix but non-blocking:
 
 - S6: Non-cryptographic random number generation (Math.random)
 - S12: PII field names in Logger calls (may be false positive — requires context)
 - S16: Session object access in hook scripts (dw.system.Session, session.privacy)
+- S17: BM controller `guard.ensure([...])` includes a state-changing method (`post`/`put`/`patch`/`delete`) but omits `'csrf'`. Scoped to files under `/bm_cartridges/` so storefront controllers with their own CSRF-token flow are not flagged. **Suggested fix:** add `'csrf'` to the guard array, e.g. `guard.ensure(['post', 'https', 'csrf', 'loggedIn'], ...)`.
+- S18: Logger call stringifies a raw error/response object — `Logger.(warn|error|info|debug|trace)(... JSON.stringify(err|error|e|response|svcResponse|svcResult|result ...))`. Whole error/response payloads can carry PII, stack traces, or vendor internals. **Suggested fix:** log only `error.message` (and a request/status code) or a purpose-built redacted view; never the whole object.
+- S19: `encodeURI(...)` used to sanitize a URL built by concatenation (`+`) or template-literal interpolation. `encodeURI` preserves URL delimiters (`/`, `?`, `&`, `=`, `#`) and single quotes, so a hostile segment can break out into a new query param or path. **Suggested fix:** `encodeURIComponent` each user-provided segment/param individually, or use a URL builder that percent-encodes per component.

--- a/.github/scripts/classify-cap-pr.sh
+++ b/.github/scripts/classify-cap-pr.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# classify-cap-pr.sh
+#
+# Shared classifier consumed by .github/workflows/gus-security-review.yml
+# (which gates on external-author AND new-app) and
+# .github/workflows/notify-slack-cap-pr.yml (which uses it only for message
+# content). Classification logic must live in exactly one place so the two
+# workflows never disagree.
+#
+# Reads the PR diff between BASE_SHA and HEAD_SHA (env vars) and emits a
+# single JSON object on stdout. Diagnostic prose is written to stderr and does
+# not pollute the JSON blob.
+#
+# Required env:
+#   BASE_SHA               PR base SHA (github.event.pull_request.base.sha)
+#   HEAD_SHA               PR head SHA (github.event.pull_request.head.sha)
+#   PR_AUTHOR_LOGIN        github.event.pull_request.user.login
+#   PR_AUTHOR_EMAIL        email of the author (blank if the API omitted it)
+#
+# Optional env:
+#   MANIFEST_PATH          override manifest.json path (repo-relative)
+#
+# Emitted JSON shape:
+#   {
+#     "added_zip": "<path>|null",
+#     "isv_dir":   "<domain>/<isv-name>|null",
+#     "domain":    "<domain>|null",
+#     "isv":       "<isv-name>|null",
+#     "manifest": {
+#       "name":     "<display name>|null",
+#       "version":  "<semver>|null",
+#       "domain":   "<domain>|null",
+#       "provider": "<provider>|null",
+#       "zip":      "<zip filename>|null"
+#     },
+#     "author": {
+#       "login":       "<gh handle>",
+#       "email":       "<email or empty>",
+#       "is_internal": true|false     # email endswith @salesforce.com
+#     },
+#     "is_new_app":         true|false, # net-new {domain}/{isv-name}/ on BASE_SHA
+#     "will_file_gus_wi":   true|false  # !is_internal AND is_new_app
+#   }
+#
+# Exit codes:
+#   0  success — JSON emitted (even when there is no CAP-relevant change; fields
+#      are then null / defaulted)
+#   2  environment / usage error
+
+set -euo pipefail
+
+: "${BASE_SHA:?BASE_SHA is required}"
+: "${HEAD_SHA:?HEAD_SHA is required}"
+: "${PR_AUTHOR_LOGIN:?PR_AUTHOR_LOGIN is required}"
+PR_AUTHOR_EMAIL="${PR_AUTHOR_EMAIL:-}"
+MANIFEST_PATH="${MANIFEST_PATH:-commerce-apps-manifest/manifest.json}"
+
+# Pick the first ADDED (A) *.zip path in the PR diff. A CAP-relevant PR either
+# adds a new ZIP under a net-new ISV directory or bumps a version by adding a
+# new ZIP under an existing one; both cases surface as an A-status *.zip diff
+# entry, so filter-A is the shared signal. Modified-only ZIPs (M) are not CAP
+# submissions and stay null here.
+added_zip="$(git diff --name-only --diff-filter=A -z "$BASE_SHA" "$HEAD_SHA" -- '**/*.zip' \
+  | tr '\0' '\n' | head -n 1 || true)"
+
+isv_dir="null"
+domain_val="null"
+isv_val="null"
+if [[ -n "$added_zip" ]]; then
+  # Path shape: {domain}/{isv-name}/{app}-v{ver}.zip
+  isv_dir="$(dirname "$added_zip")"
+  domain_val="$(printf '%s' "$isv_dir" | cut -d/ -f1)"
+  isv_val="$(printf '%s' "$isv_dir" | cut -d/ -f2)"
+fi
+
+# is_new_app: does {domain}/{isv-name}/ exist as a tree on BASE_SHA?
+# Absent = net-new (external submission); present = version bump.
+is_new_app="false"
+if [[ -n "$added_zip" && "$isv_dir" != "null" ]]; then
+  if git cat-file -e "$BASE_SHA:$isv_dir" 2>/dev/null; then
+    is_new_app="false"
+  else
+    is_new_app="true"
+  fi
+fi
+
+# Manifest entry lookup — best-effort. The manifest may not yet describe the
+# newly-added ZIP (PRs sometimes stage the ZIP without the manifest update);
+# treat that as null fields rather than an error, so the classifier still emits
+# a usable blob for the Slack canary.
+#
+# Read the manifest via `git show "$HEAD_SHA:$MANIFEST_PATH"` — NOT via a
+# working-tree file read. The workflows that call this classifier run under
+# `pull_request_target`, which checks out the base branch (trusted) with
+# secrets available; the PR head is fetched as a git object only. Reading the
+# manifest through git means we never touch PR-head files on disk, so a
+# fork's manipulated manifest can't influence anything beyond the string
+# fields we then pass through `jq --arg` (which quotes them safely).
+m_name="null"; m_version="null"; m_domain="null"; m_provider="null"; m_zip="null"
+if [[ -n "$added_zip" ]]; then
+  manifest_json="$(git show "$HEAD_SHA:$MANIFEST_PATH" 2>/dev/null || true)"
+  if [[ -n "$manifest_json" ]]; then
+    zip_basename="$(basename "$added_zip")"
+    entry="$(jq -c --arg z "$zip_basename" '
+      [
+        to_entries[]
+        | select(.value | type == "array")
+        | .value[]?
+        | select(type == "object" and (.zip? == $z))
+      ] | .[0] // null
+    ' <<< "$manifest_json")"
+
+    if [[ "$entry" != "null" && -n "$entry" ]]; then
+      m_name="$(jq -r '.name // "null"' <<< "$entry")"
+      m_version="$(jq -r '.version // "null"' <<< "$entry")"
+      m_domain="$(jq -r '.domain // "null"' <<< "$entry")"
+      m_provider="$(jq -r '.provider // "null"' <<< "$entry")"
+      m_zip="$(jq -r '.zip // "null"' <<< "$entry")"
+    fi
+  fi
+fi
+
+# Internal author check. External submitters (the reason this workflow exists)
+# must not have an @salesforce.com email; only well-formed emails whose entire
+# domain part is exactly `salesforce.com` are treated as internal. A plain
+# suffix match (`*@salesforce.com`) would let a crafted email like
+# `hostile" ; rm -rf / ; echo "@salesforce.com` pass — anchoring against a
+# valid local-part rules that out.
+is_internal="false"
+if [[ "$PR_AUTHOR_EMAIL" =~ ^[A-Za-z0-9._%+-]+@salesforce\.com$ ]]; then
+  is_internal="true"
+fi
+
+will_file_gus_wi="false"
+if [[ "$is_internal" == "false" && "$is_new_app" == "true" ]]; then
+  will_file_gus_wi="true"
+fi
+
+# Emit a single JSON blob. jq builds it so quoting is safe even when the
+# manifest name / other fields contain characters that would break a
+# hand-assembled string.
+jq -n \
+  --arg added_zip "$added_zip" \
+  --arg isv_dir "$isv_dir" \
+  --arg domain "$domain_val" \
+  --arg isv "$isv_val" \
+  --arg m_name "$m_name" \
+  --arg m_version "$m_version" \
+  --arg m_domain "$m_domain" \
+  --arg m_provider "$m_provider" \
+  --arg m_zip "$m_zip" \
+  --arg author_login "$PR_AUTHOR_LOGIN" \
+  --arg author_email "$PR_AUTHOR_EMAIL" \
+  --argjson is_internal "$is_internal" \
+  --argjson is_new_app "$is_new_app" \
+  --argjson will_file "$will_file_gus_wi" \
+  '{
+    added_zip: (if $added_zip == "" then null else $added_zip end),
+    isv_dir:   (if $isv_dir == "null" then null else $isv_dir end),
+    domain:    (if $domain == "null" then null else $domain end),
+    isv:       (if $isv == "null" then null else $isv end),
+    manifest: {
+      name:     (if $m_name == "null" then null else $m_name end),
+      version:  (if $m_version == "null" then null else $m_version end),
+      domain:   (if $m_domain == "null" then null else $m_domain end),
+      provider: (if $m_provider == "null" then null else $m_provider end),
+      zip:      (if $m_zip == "null" then null else $m_zip end)
+    },
+    author: {
+      login:       $author_login,
+      email:       $author_email,
+      is_internal: $is_internal
+    },
+    is_new_app:       $is_new_app,
+    will_file_gus_wi: $will_file
+  }'

--- a/.github/scripts/security-scan.sh
+++ b/.github/scripts/security-scan.sh
@@ -284,6 +284,43 @@ for f in ${HOOK_SCRIPT_FILES[@]+"${HOOK_SCRIPT_FILES[@]}"}; do
   done < <(grep -nE 'dw\.system\.Session|require.*dw/system/Session|session\.(privacy|custom|forms)' "$f" 2>/dev/null | head -5)
 done
 
+# S17: BM controller guard.ensure includes a state-changing method but omits 'csrf' (WARN)
+# Scoped to /bm_cartridges/ so storefront controllers (which use their own CSRF token flow) are not flagged.
+for f in ${JS_FILES[@]+"${JS_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  case "$f" in */bm_cartridges/*) ;; *) continue ;; esac
+  while IFS= read -r match; do
+    # $match is "N:<line contents>"; strip the line-num prefix before shape checks
+    body="${match#*:}"
+    # Must include a state-changing method: post|put|patch|delete
+    if echo "$body" | grep -qE "['\"](post|put|patch|delete)['\"]"; then
+      # Must omit 'csrf'
+      if ! echo "$body" | grep -qE "['\"]csrf['\"]"; then
+        warn "$f" "BM guard.ensure includes a state-changing method but omits 'csrf' — add CSRF protection: $match"
+      fi
+    fi
+  done < <(grep -nE 'guard\.ensure\s*\(\s*\[[^]]*\]' "$f" 2>/dev/null | strip_comments | head -5)
+done
+
+# S18: Raw error/response objects stringified into logs (WARN)
+# Recommend logging only error.message or a redacted status; JSON.stringify(err|response|...) can leak PII, stack, or vendor payloads.
+for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    warn "$f" "Raw error/response object stringified in log — log only the message or a redacted view: $line"
+  done < <(grep -nE '(Logger|logger|log)\.(warn|error|info|debug|trace)\s*\(.*JSON\.stringify\s*\(\s*(err|error|e|response|svcResponse|svcResult|result)\b' "$f" 2>/dev/null | strip_comments | head -5)
+done
+
+# S19: encodeURI() used to sanitize concatenated/interpolated URLs (WARN)
+# encodeURI preserves URL delimiters (/ ? & = # ') — use encodeURIComponent per user-provided segment/param instead.
+# \bencodeURI\b requires the next char be a non-word so encodeURIComponent( does not match.
+for f in ${ALL_CODE_FILES[@]+"${ALL_CODE_FILES[@]}"}; do
+  [[ -z "$f" ]] && continue
+  while IFS= read -r line; do
+    warn "$f" "encodeURI() with concatenation or template-literal argument — preserves URL delimiters; use encodeURIComponent per segment: $line"
+  done < <(grep -nE '\bencodeURI\s*\([^)]*(\+|\$\{)' "$f" 2>/dev/null | strip_comments | head -5)
+done
+
 echo ""
 
 # ============================ PERFORMANCE ===================================

--- a/.github/scripts/test-classify-cap-pr.sh
+++ b/.github/scripts/test-classify-cap-pr.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# test-classify-cap-pr.sh
+#
+# Fixture-based tests for classify-cap-pr.sh. Same shape as
+# test-security-scan.sh / test-validate-*.sh: each case builds a throwaway
+# git repo containing a `base` and `head` commit, then invokes the classifier
+# with BASE_SHA/HEAD_SHA/PR_AUTHOR_LOGIN/PR_AUTHOR_EMAIL set from that repo.
+#
+# The classifier reads MANIFEST_PATH (defaulting to
+# commerce-apps-manifest/manifest.json) relative to the current working
+# directory, so tests cd into their fixture repo before invoking.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CLASSIFY="$SCRIPT_DIR/classify-cap-pr.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=""
+cleanup() { [[ -n "$TMPDIR_ROOT" ]] && rm -rf "$TMPDIR_ROOT"; }
+trap cleanup EXIT
+TMPDIR_ROOT="$(mktemp -d)"
+
+# Build an isolated git repo for one test case. Writes two commits so
+# BASE_SHA and HEAD_SHA are meaningful. Echoes the repo path on stdout;
+# the caller populates it via the on_base / on_head hooks.
+mkrepo() {
+  local d
+  d="$(mktemp -d "$TMPDIR_ROOT/repo_XXXXXX")"
+  git -C "$d" init -q -b main
+  git -C "$d" config user.email "test@example.com"
+  git -C "$d" config user.name "test"
+  printf '%s' "$d"
+}
+
+commit_all() {
+  local repo="$1" msg="$2"
+  git -C "$repo" add -A
+  git -C "$repo" commit -q --allow-empty -m "$msg"
+}
+
+run_classify() {
+  # Args: repo, author_login, author_email; sets JSON output var.
+  local repo="$1" login="$2" email="$3"
+  local base_sha head_sha
+  base_sha="$(git -C "$repo" rev-parse HEAD~1)"
+  head_sha="$(git -C "$repo" rev-parse HEAD)"
+  (
+    cd "$repo" || exit 1
+    BASE_SHA="$base_sha" HEAD_SHA="$head_sha" \
+      PR_AUTHOR_LOGIN="$login" PR_AUTHOR_EMAIL="$email" \
+      bash "$CLASSIFY"
+  )
+}
+
+assert_field() {
+  local json="$1" jq_path="$2" want="$3" desc="$4"
+  local got
+  got="$(jq -r "$jq_path" <<< "$json")"
+  if [[ "$got" == "$want" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc  (want '$want', got '$got')"
+    echo "    json: $json"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== classify-cap-pr.sh tests ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 1: Net-new external app.
+# ---------------------------------------------------------------------------
+# External contributor adds a brand-new {domain}/{isv-name}/ dir with a ZIP
+# and a matching manifest entry. Gate must fire (will_file_gus_wi=true).
+echo "--- Case 1: net-new external app ---"
+repo="$(mkrepo)"
+
+mkdir -p "$repo/commerce-apps-manifest"
+cat > "$repo/commerce-apps-manifest/manifest.json" <<'EOF'
+{
+  "tax": []
+}
+EOF
+commit_all "$repo" "base"
+
+mkdir -p "$repo/tax/acme"
+printf 'PK\x03\x04fake-zip' > "$repo/tax/acme/acme-tax-v1.0.0.zip"
+cat > "$repo/commerce-apps-manifest/manifest.json" <<'EOF'
+{
+  "tax": [
+    {
+      "id": "acme-tax",
+      "name": "Acme Tax",
+      "description": "Automate your Acme tax.",
+      "iconName": "acme.png",
+      "domain": "tax",
+      "type": "app",
+      "provider": "thirdParty",
+      "version": "1.0.0",
+      "zip": "acme-tax-v1.0.0.zip",
+      "sha256": "abc"
+    }
+  ]
+}
+EOF
+commit_all "$repo" "head"
+
+json="$(run_classify "$repo" "external-user" "user@example.com")"
+assert_field "$json" '.added_zip'          "tax/acme/acme-tax-v1.0.0.zip" "added_zip is the new ZIP"
+assert_field "$json" '.isv_dir'            "tax/acme"                     "isv_dir resolves"
+assert_field "$json" '.domain'             "tax"                          "domain is tax"
+assert_field "$json" '.isv'                "acme"                         "isv is acme"
+assert_field "$json" '.manifest.name'      "Acme Tax"                     "manifest.name reads from manifest"
+assert_field "$json" '.manifest.version'   "1.0.0"                        "manifest.version reads from manifest"
+assert_field "$json" '.manifest.provider'  "thirdParty"                   "manifest.provider reads from manifest"
+assert_field "$json" '.author.login'       "external-user"                "author.login"
+assert_field "$json" '.author.email'       "user@example.com"             "author.email"
+assert_field "$json" '.author.is_internal' "false"                        "external email is_internal=false"
+assert_field "$json" '.is_new_app'         "true"                         "net-new dir is_new_app=true"
+assert_field "$json" '.will_file_gus_wi'   "true"                         "external + new-app => will_file_gus_wi=true"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 2: Version bump by external author.
+# ---------------------------------------------------------------------------
+# {domain}/{isv-name}/ already exists on base; the head adds a new ZIP file
+# under the same directory. is_new_app=false, so no GUS WI even though the
+# submitter is external.
+echo "--- Case 2: version bump by external ---"
+repo="$(mkrepo)"
+
+mkdir -p "$repo/tax/acme" "$repo/commerce-apps-manifest"
+printf 'PK\x03\x04v100' > "$repo/tax/acme/acme-tax-v1.0.0.zip"
+cat > "$repo/commerce-apps-manifest/manifest.json" <<'EOF'
+{
+  "tax": [
+    {
+      "id": "acme-tax", "name": "Acme Tax", "description": "d",
+      "iconName": "acme.png", "domain": "tax", "type": "app",
+      "provider": "thirdParty", "version": "1.0.0",
+      "zip": "acme-tax-v1.0.0.zip", "sha256": "abc"
+    }
+  ]
+}
+EOF
+commit_all "$repo" "base"
+
+printf 'PK\x03\x04v110' > "$repo/tax/acme/acme-tax-v1.1.0.zip"
+cat > "$repo/commerce-apps-manifest/manifest.json" <<'EOF'
+{
+  "tax": [
+    {
+      "id": "acme-tax", "name": "Acme Tax", "description": "d",
+      "iconName": "acme.png", "domain": "tax", "type": "app",
+      "provider": "thirdParty", "version": "1.1.0",
+      "zip": "acme-tax-v1.1.0.zip", "sha256": "def"
+    }
+  ]
+}
+EOF
+commit_all "$repo" "head"
+
+json="$(run_classify "$repo" "external-user" "user@example.com")"
+assert_field "$json" '.added_zip'          "tax/acme/acme-tax-v1.1.0.zip" "added_zip is the new version's ZIP"
+assert_field "$json" '.is_new_app'         "false"                        "existing dir => is_new_app=false"
+assert_field "$json" '.author.is_internal' "false"                        "external still external"
+assert_field "$json" '.will_file_gus_wi'   "false"                        "version bump => no GUS WI"
+assert_field "$json" '.manifest.version'   "1.1.0"                        "manifest reflects new version"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 3: Salesforce-authored new app.
+# ---------------------------------------------------------------------------
+# Author email ends in @salesforce.com. Even a genuinely-new ISV dir must
+# not create a GUS WI — internal submissions are triaged out-of-band.
+echo "--- Case 3: Salesforce-authored new app ---"
+repo="$(mkrepo)"
+
+mkdir -p "$repo/commerce-apps-manifest"
+printf '{"tax":[]}' > "$repo/commerce-apps-manifest/manifest.json"
+commit_all "$repo" "base"
+
+mkdir -p "$repo/tax/salesforce-thing"
+printf 'PK\x03\x04sf' > "$repo/tax/salesforce-thing/sf-thing-v1.0.0.zip"
+printf '{"tax":[{"id":"sf-thing","name":"SF Thing","description":"d","iconName":"sf.png","domain":"tax","type":"app","provider":"salesforce","version":"1.0.0","zip":"sf-thing-v1.0.0.zip","sha256":"x"}]}' \
+  > "$repo/commerce-apps-manifest/manifest.json"
+commit_all "$repo" "head"
+
+json="$(run_classify "$repo" "sf-user" "someone@salesforce.com")"
+assert_field "$json" '.is_new_app'         "true"                          "still is_new_app=true"
+assert_field "$json" '.author.is_internal' "true"                          "salesforce.com email => internal"
+assert_field "$json" '.will_file_gus_wi'   "false"                         "internal author => no GUS WI"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 4: Non-ZIP-only diff.
+# ---------------------------------------------------------------------------
+# The workflow filters PR events by paths: **/*.zip so this exact shape
+# does not trigger the workflow at all — but the classifier is also invoked
+# on manual reruns and must degrade cleanly to nulls without crashing when
+# there is no added ZIP.
+echo "--- Case 4: non-ZIP-only diff ---"
+repo="$(mkrepo)"
+
+mkdir -p "$repo/commerce-apps-manifest"
+printf '{"tax":[]}' > "$repo/commerce-apps-manifest/manifest.json"
+commit_all "$repo" "base"
+
+printf 'update docs\n' > "$repo/README.md"
+commit_all "$repo" "head"
+
+json="$(run_classify "$repo" "docs-user" "user@example.com")"
+assert_field "$json" '.added_zip'          "null"    "no added zip"
+assert_field "$json" '.isv_dir'            "null"    "no isv_dir"
+assert_field "$json" '.is_new_app'         "false"   "no zip => not a new app"
+assert_field "$json" '.will_file_gus_wi'   "false"   "no zip => no GUS WI"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Case 5: Injection safety — author email with shell metachars.
+# ---------------------------------------------------------------------------
+# The classifier passes untrusted fields via jq --arg (never interpolated
+# into shell). A crafted email must not affect JSON structure or shell
+# behavior.
+echo "--- Case 5: hostile author email ---"
+repo="$(mkrepo)"
+mkdir -p "$repo/commerce-apps-manifest"
+printf '{"tax":[]}' > "$repo/commerce-apps-manifest/manifest.json"
+commit_all "$repo" "base"
+printf 'x' > "$repo/README.md"
+commit_all "$repo" "head"
+
+hostile_email='" ; rm -rf / ; echo "@salesforce.com'
+json="$(run_classify "$repo" 'attacker' "$hostile_email")"
+assert_field "$json" '.author.email' "$hostile_email" "hostile email preserved verbatim as string"
+assert_field "$json" '.author.is_internal' "false" "hostile email does not falsely satisfy @salesforce.com"
+echo ""
+
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.github/scripts/test-security-scan.sh
+++ b/.github/scripts/test-security-scan.sh
@@ -584,6 +584,104 @@ assert_no_warning "clean hook has no session warning" "Session access" "$cap"
 echo ""
 
 # ---------------------------------------------------------------------------
+# S17: BM guard.ensure without 'csrf' on state-changing method (WARN)
+# ---------------------------------------------------------------------------
+echo "--- S17: BM CSRF ---"
+
+cap="$(mkcap)"; mkdir -p "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers"
+printf "server.get('Show', guard.ensure(['get','https','loggedIn']), function(req, res, next){});\n" > "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers/AvaTaxAdmin.js"
+assert_passes "BM guard.ensure with only 'get' does not warn" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers"
+printf "server.post('Save', guard.ensure(['post','https','loggedIn']), function(req, res, next){});\n" > "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers/AvaTaxAdmin.js"
+assert_warns "BM guard.ensure with 'post' but no 'csrf' warns" "BM guard.ensure" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers"
+printf "server.post('Save', guard.ensure(['post','https','csrf','loggedIn']), function(req, res, next){});\n" > "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers/AvaTaxAdmin.js"
+assert_no_warning "BM guard.ensure with 'post' and 'csrf' does not warn" "BM guard.ensure" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers"
+printf "server.put('Update', guard.ensure(['put','https']), function(req, res, next){});\n" > "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers/AvaTaxAdmin.js"
+assert_warns "BM guard.ensure with 'put' but no 'csrf' warns" "BM guard.ensure" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers"
+printf "server.patch('Patch', guard.ensure(['patch','https']), function(req, res, next){});\n" > "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers/AvaTaxAdmin.js"
+assert_warns "BM guard.ensure with 'patch' but no 'csrf' warns" "BM guard.ensure" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers"
+printf "server.delete('Purge', guard.ensure(['delete','https']), function(req, res, next){});\n" > "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers/AvaTaxAdmin.js"
+assert_warns "BM guard.ensure with 'delete' but no 'csrf' warns" "BM guard.ensure" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/cartridges/site_cartridges/int_avatax/cartridge/controllers"
+printf "server.post('Save', guard.ensure(['post','https','loggedIn']), function(req, res, next){});\n" > "$cap/cartridges/site_cartridges/int_avatax/cartridge/controllers/Site.js"
+assert_no_warning "storefront (non-BM) guard.ensure with 'post' does not warn (scoped to BM only)" "BM guard.ensure" "$cap"
+
+cap="$(mkcap)"; mkdir -p "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers"
+printf "// server.post('Save', guard.ensure(['post','https','loggedIn']), function(req, res, next){});\n" > "$cap/cartridges/bm_cartridges/bm_avatax/cartridge/controllers/AvaTaxAdmin.js"
+assert_no_warning "commented BM guard.ensure is ignored" "BM guard.ensure" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S18: Raw error/response objects stringified into logs (WARN)
+# ---------------------------------------------------------------------------
+echo "--- S18: Raw error/response in logs ---"
+
+cap="$(mkcap)"; printf "logger.error('AvaTax API call failed: ' + JSON.stringify(response.details));\n" > "$cap/app.js"
+assert_warns "JSON.stringify(response...) in logger.error warns" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "Logger.warn('Failed: ' + JSON.stringify(err));\n" > "$cap/app.js"
+assert_warns "JSON.stringify(err) in Logger.warn warns" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "log.debug('svc: ' + JSON.stringify(svcResponse));\n" > "$cap/app.js"
+assert_warns "JSON.stringify(svcResponse) in log.debug warns" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "logger.info('svc: ' + JSON.stringify(result));\n" > "$cap/app.js"
+assert_warns "JSON.stringify(result) in logger.info warns" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "log.trace('svc: ' + JSON.stringify(svcResult));\n" > "$cap/app.js"
+assert_warns "JSON.stringify(svcResult) in log.trace warns" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "Logger.error('svc: ' + JSON.stringify(error));\n" > "$cap/app.js"
+assert_warns "JSON.stringify(error) in Logger.error warns" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "logger.warn('svc: ' + JSON.stringify(e));\n" > "$cap/app.js"
+assert_warns "JSON.stringify(e) in logger.warn warns" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "logger.error('AvaTax API call failed: ' + error.message);\n" > "$cap/app.js"
+assert_no_warning "logger with error.message does not warn" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "var payload = JSON.stringify(err);\nlogger.info('ok');\n" > "$cap/app.js"
+assert_no_warning "JSON.stringify outside a log call does not warn" "Raw error/response" "$cap"
+
+cap="$(mkcap)"; printf "// logger.error('x: ' + JSON.stringify(err));\n" > "$cap/app.js"
+assert_no_warning "commented log with JSON.stringify(err) is ignored" "Raw error/response" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# S19: encodeURI with concatenation / template-literal args (WARN)
+# ---------------------------------------------------------------------------
+echo "--- S19: encodeURI misuse ---"
+
+cap="$(mkcap)"; printf "var u = encodeURI('/api/' + userInput);\n" > "$cap/app.js"
+assert_warns "encodeURI with '+' concatenation warns" "encodeURI()" "$cap"
+
+cap="$(mkcap)"; printf 'var u = encodeURI(`/api/${userInput}`);\n' > "$cap/app.js"
+assert_warns "encodeURI with template-literal interpolation warns" "encodeURI()" "$cap"
+
+cap="$(mkcap)"; printf "var u = encodeURI('/api/static/path');\n" > "$cap/app.js"
+assert_no_warning "encodeURI with static string does not warn" "encodeURI()" "$cap"
+
+cap="$(mkcap)"; printf "var u = encodeURIComponent(userInput + '/x');\n" > "$cap/app.js"
+assert_no_warning "encodeURIComponent (not encodeURI) does not warn" "encodeURI()" "$cap"
+
+cap="$(mkcap)"; printf "// var u = encodeURI('/api/' + userInput);\n" > "$cap/app.js"
+assert_no_warning "commented encodeURI is ignored" "encodeURI()" "$cap"
+
+echo ""
+
+# ---------------------------------------------------------------------------
 # P1: Service profile timeout (BLOCK)
 # ---------------------------------------------------------------------------
 echo "--- P1: Service profile timeout ---"

--- a/.github/workflows/gus-security-review.yml
+++ b/.github/workflows/gus-security-review.yml
@@ -1,0 +1,271 @@
+name: GUS Security Review Auto-file
+
+# When an external contributor opens a PR that adds a brand-new commerce app
+# to this registry, the C360 Product Security Advisors team needs a GUS User
+# Story queued up immediately so the security review can start in parallel
+# with maintainer review. This workflow runs on every CAP PR, uses the shared
+# classifier to decide whether the PR qualifies (external author AND net-new
+# ISV directory), and — if it does — creates exactly one ADM_Work__c record
+# under the C360 PSA: Commerce Apps - Submissions epic and posts a link back
+# to the PR. Idempotent via a hidden HTML marker in the PR comment so
+# synchronize events don't file duplicate WIs.
+#
+# Trigger safety: this uses `pull_request_target`, which runs from the
+# TRUSTED base branch with secrets available (needed so fork PRs can auth
+# to GUS). The steps below check out ONLY the base ref, then do a bare
+# `git fetch` of the PR head into the object database — HEAD content is
+# reachable as git objects (`git show HEAD_SHA:path`, `git diff BASE HEAD`)
+# but is never on the working tree in a way that a subsequent step could
+# execute or import. The classifier reads the PR-head manifest via
+# `git show` for the same reason. Do not add `checkout` of head.sha or any
+# step that shells into head-provided code.
+#
+# Injection safety: every untrusted PR field (title, author login/email,
+# manifest values from the shared classifier) is passed via env: and
+# referenced as a shell variable inside run: — never interpolated directly
+# via ${{ ... }} into a script body.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+    paths:
+      - '**/*.zip'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  gus-security-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base (trusted)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+
+      - name: Fetch PR head as git object only
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin \
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}"
+          if ! git cat-file -e "$HEAD_SHA"; then
+            echo "::error::PR head SHA $HEAD_SHA is not reachable after fetch"
+            exit 1
+          fi
+
+      - name: Install Salesforce CLI
+        run: |
+          set -euo pipefail
+          npm install --global @salesforce/cli
+
+      - name: Classify PR
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_EMAIL: ${{ github.event.pull_request.user.email }}
+        run: |
+          set -euo pipefail
+          classification="$(bash .github/scripts/classify-cap-pr.sh)"
+          printf '%s\n' "$classification"
+
+          {
+            printf 'classification<<EOF\n'
+            printf '%s\n' "$classification"
+            printf 'EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            printf 'will_file_gus_wi=%s\n' "$(jq -r '.will_file_gus_wi' <<< "$classification")"
+            printf 'is_new_app=%s\n'       "$(jq -r '.is_new_app' <<< "$classification")"
+            printf 'is_internal=%s\n'      "$(jq -r '.author.is_internal' <<< "$classification")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Skip if not an external new-app submission
+        if: steps.classify.outputs.will_file_gus_wi != 'true'
+        env:
+          IS_NEW_APP: ${{ steps.classify.outputs.is_new_app }}
+          IS_INTERNAL: ${{ steps.classify.outputs.is_internal }}
+        run: |
+          echo "Not an external net-new CAP submission — no GUS WI to file."
+          echo "  is_new_app  = $IS_NEW_APP"
+          echo "  is_internal = $IS_INTERNAL"
+
+      # Idempotency gate — the create step below only runs if no existing PR
+      # comment carries the hidden marker `<!-- gus-security-review-wi -->`.
+      # We check BEFORE authenticating to GUS so a re-run on an already-filed
+      # PR never pays the sfdx-url login cost.
+      - name: Check for existing WI marker on the PR
+        id: marker
+        if: steps.classify.outputs.will_file_gus_wi == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --jq '.[].body' | grep -qF '<!-- gus-security-review-wi -->'; then
+            echo "already_filed=true" >> "$GITHUB_OUTPUT"
+            echo "Existing GUS WI marker found on PR #$PR_NUMBER — nothing to do."
+          else
+            echo "already_filed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to GUS via sfdx-url
+        if: >-
+          steps.classify.outputs.will_file_gus_wi == 'true' &&
+          steps.marker.outputs.already_filed == 'false'
+        env:
+          GUS_SFDX_AUTH_URL: ${{ secrets.GUS_SFDX_AUTH_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GUS_SFDX_AUTH_URL:-}" ]]; then
+            echo "::error::Secret GUS_SFDX_AUTH_URL is not configured. See docs/maintainer-setup.md."
+            exit 1
+          fi
+          # Write the auth URL to a file so it never appears on a command
+          # line where a diagnostic dump could leak it into process logs.
+          printf '%s' "$GUS_SFDX_AUTH_URL" > "$RUNNER_TEMP/gus-auth.txt"
+          sf org login sfdx-url --sfdx-url-file "$RUNNER_TEMP/gus-auth.txt" --alias gus --set-default
+          rm -f "$RUNNER_TEMP/gus-auth.txt"
+          sf org display --target-org gus --json | jq '.result.username // "unknown"'
+
+      - name: Create GUS Work Item
+        id: create_wi
+        if: >-
+          steps.classify.outputs.will_file_gus_wi == 'true' &&
+          steps.marker.outputs.already_filed == 'false'
+        env:
+          CLASSIFICATION: ${{ steps.classify.outputs.classification }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_EMAIL: ${{ github.event.pull_request.user.email }}
+        run: |
+          set -euo pipefail
+
+          # Extract classifier fields into shell variables. Values come from
+          # `jq -r` on JSON; jq never eval's its inputs.
+          zip_path="$(jq -r '.added_zip // "unknown"'      <<< "$CLASSIFICATION")"
+          domain="$(jq -r '.domain // "unknown"'           <<< "$CLASSIFICATION")"
+          isv="$(jq -r '.isv // "unknown"'                 <<< "$CLASSIFICATION")"
+          app_name="$(jq -r '.manifest.name // "unknown"'  <<< "$CLASSIFICATION")"
+          app_version="$(jq -r '.manifest.version // "unknown"' <<< "$CLASSIFICATION")"
+          provider="$(jq -r '.manifest.provider // "unknown"'   <<< "$CLASSIFICATION")"
+          zip_basename="$(basename "$zip_path")"
+
+          # Details__c is HTML with three <h2> sections mirroring example WI
+          # W-23291307. jq --arg quotes every substitution safely.
+          details_html="$(jq -n \
+            --arg pr_url "$PR_URL" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg pr_title "$PR_TITLE" \
+            --arg author "$PR_AUTHOR_LOGIN" \
+            --arg email "$PR_AUTHOR_EMAIL" \
+            --arg app_name "$app_name" \
+            --arg app_version "$app_version" \
+            --arg domain "$domain" \
+            --arg provider "$provider" \
+            --arg isv "$isv" \
+            --arg zip "$zip_basename" \
+            -r '
+              "<h2>User Story</h2>" +
+              "<p>An external contributor has opened a pull request submitting a new " +
+              "third-party Commerce App to <code>SalesforceCommerceCloud/commerce-apps</code>. " +
+              "Please conduct the security review before the PR is merged.</p>" +
+              "<h2>Overview</h2>" +
+              "<ul>" +
+              "<li><b>Pull request:</b> <a href=\"" + $pr_url + "\">#" + $pr_number + " " + ($pr_title | @html) + "</a></li>" +
+              "<li><b>Submitter:</b> " + ($author | @html) + " &lt;" + ($email | @html) + "&gt;</li>" +
+              "<li><b>App name:</b> " + ($app_name | @html) + "</li>" +
+              "<li><b>Version:</b> " + ($app_version | @html) + "</li>" +
+              "<li><b>Domain:</b> " + ($domain | @html) + "</li>" +
+              "<li><b>Provider:</b> " + ($provider | @html) + "</li>" +
+              "<li><b>ISV:</b> " + ($isv | @html) + "</li>" +
+              "<li><b>ZIP:</b> " + ($zip | @html) + "</li>" +
+              "</ul>" +
+              "<h2>Acceptance Criteria</h2>" +
+              "<ul>" +
+              "<li>Security review of the submitted CAP is complete and signed off, or blocking issues are filed back on the PR.</li>" +
+              "<li>PR is not merged until this review is closed.</li>" +
+              "</ul>"
+            ')"
+
+          # Build the ADM_Work__c create payload as a JSON file. Using a file
+          # (not a command-line arg) keeps large HTML off argv.
+          payload_file="$RUNNER_TEMP/adm-work-payload.json"
+          jq -n \
+            --arg subject "External CAP submission: $app_name ($isv) — PR #$PR_NUMBER" \
+            --arg details "$details_html" \
+            '{
+              RecordTypeId:    "0129000000006gDAAQ",
+              Type__c:         "User Story",
+              Status__c:       "New",
+              Epic__c:         "a3QEE000002VGqX2AW",
+              Product_Tag__c:  "a1aEE000001NDFJYA4",
+              Scrum_Team__c:   "a00EE00001Ux7RuYAJ",
+              Assignee__c:     "005B0000006B9w0IAC",
+              Subject__c:      $subject,
+              Details__c:      $details,
+              Priority__c:     "P2"
+            }' > "$payload_file"
+
+          create_response="$(sf data create record \
+            --target-org gus \
+            --sobject ADM_Work__c \
+            --file "$payload_file" \
+            --json)"
+
+          wi_id="$(jq -r '.result.id // empty' <<< "$create_response")"
+          if [[ -z "$wi_id" ]]; then
+            echo "::error::Failed to create ADM_Work__c record"
+            printf '%s\n' "$create_response"
+            exit 1
+          fi
+
+          wi_name="$(sf data query --target-org gus --json \
+            --query "SELECT Name FROM ADM_Work__c WHERE Id='$wi_id'" \
+            | jq -r '.result.records[0].Name // empty')"
+
+          if [[ -z "$wi_name" ]]; then
+            echo "::error::Created ADM_Work__c $wi_id but could not resolve its Name"
+            exit 1
+          fi
+
+          echo "Created GUS WI $wi_name (Id $wi_id)"
+          echo "wi_id=$wi_id"     >> "$GITHUB_OUTPUT"
+          echo "wi_name=$wi_name" >> "$GITHUB_OUTPUT"
+
+      - name: Post PR comment with WI link
+        if: >-
+          steps.classify.outputs.will_file_gus_wi == 'true' &&
+          steps.marker.outputs.already_filed == 'false' &&
+          steps.create_wi.outputs.wi_name != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          WI_ID: ${{ steps.create_wi.outputs.wi_id }}
+          WI_NAME: ${{ steps.create_wi.outputs.wi_name }}
+        run: |
+          set -euo pipefail
+
+          body_file="$RUNNER_TEMP/pr-comment.md"
+          {
+            printf '<!-- gus-security-review-wi -->\n'
+            printf '## Security review queued: [%s](https://gus.lightning.force.com/lightning/r/ADM_Work__c/%s/view)\n\n' \
+              "$WI_NAME" "$WI_ID"
+            printf 'A GUS Work Item has been auto-filed under the C360 PSA: Commerce Apps - Submissions epic. '
+            printf '**This PR must not be merged until the security review is complete.**\n'
+          } > "$body_file"
+
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            -f body=@"$body_file"

--- a/.github/workflows/gus-security-review.yml
+++ b/.github/workflows/gus-security-review.yml
@@ -38,6 +38,12 @@ permissions:
 jobs:
   gus-security-review:
     runs-on: ubuntu-latest
+    # Temporarily disabled: the GUS Connected App backing GUS_SFDX_AUTH_URL
+    # enforces IP restrictions, so refresh-token auth from GitHub-hosted
+    # runners fails with "RefreshTokenAuthError: ip restricted". Re-enable
+    # by removing this `if:` once a Connected App with "Relax IP
+    # restrictions" is provisioned and the secret is rotated.
+    if: false
     steps:
       - name: Checkout base (trusted)
         uses: actions/checkout@v4

--- a/.github/workflows/notify-slack-cap-pr.yml
+++ b/.github/workflows/notify-slack-cap-pr.yml
@@ -1,0 +1,168 @@
+name: Notify Slack — CAP PR canary
+
+# Slack canary companion to gus-security-review.yml. Fires on every PR that
+# touches **/*.zip regardless of author, and posts one message per PR
+# (idempotent via a hidden HTML marker in a PR comment) so the security team
+# can visibly confirm the trigger + classifier are behaving even on PRs
+# where the GUS gate won't file a WI. Failure isolation: this workflow is
+# independent of gus-security-review.yml — if the GUS side breaks, this
+# canary still fires, so operators can distinguish a trigger failure from a
+# GUS-gate skip.
+#
+# Trigger safety: this uses `pull_request_target`, which runs from the
+# TRUSTED base branch with secrets available (needed so fork PRs can post
+# to the SLACK_WEBHOOK_URL). Only the base ref is checked out; the PR head
+# is fetched as a git object and read via `git show` / `git diff` — no
+# head-provided code is executed. Do not add `checkout` of head.sha here.
+#
+# Injection safety: every untrusted PR field (title, author login/email,
+# manifest values from the shared classifier) is passed via env: and
+# referenced as a shell variable inside run: — never interpolated directly
+# via ${{ ... }} into a script body.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+    paths:
+      - '**/*.zip'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout base (trusted)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 0
+
+      - name: Fetch PR head as git object only
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin \
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr/${PR_NUMBER}"
+          if ! git cat-file -e "$HEAD_SHA"; then
+            echo "::error::PR head SHA $HEAD_SHA is not reachable after fetch"
+            exit 1
+          fi
+
+      - name: Classify PR
+        id: classify
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR_EMAIL: ${{ github.event.pull_request.user.email }}
+        run: |
+          set -euo pipefail
+          classification="$(bash .github/scripts/classify-cap-pr.sh)"
+          printf '%s\n' "$classification"
+
+          {
+            printf 'classification<<EOF\n'
+            printf '%s\n' "$classification"
+            printf 'EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Check for existing Slack marker on the PR
+        id: marker
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+              --jq '.[].body' | grep -qF '<!-- slack-cap-notify -->'; then
+            echo "already_notified=true" >> "$GITHUB_OUTPUT"
+            echo "Existing Slack marker found on PR #$PR_NUMBER — nothing to do."
+          else
+            echo "already_notified=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build Slack payload
+        id: payload
+        if: steps.marker.outputs.already_notified == 'false'
+        env:
+          CLASSIFICATION: ${{ steps.classify.outputs.classification }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+
+          payload_file="$RUNNER_TEMP/slack-payload.json"
+
+          # Every substitution is fed through jq --arg (or --argjson for
+          # booleans) so a hostile PR title / manifest name cannot break the
+          # JSON envelope.
+          jq -n \
+            --arg pr_url "$PR_URL" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg pr_title "$PR_TITLE" \
+            --argjson c "$CLASSIFICATION" \
+            '
+            def yn(b): if b then "yes" else "no" end;
+
+            {
+              text: ("CAP PR #" + $pr_number + ": " + ($c.manifest.name // "unknown") + " — "
+                    + (if $c.will_file_gus_wi then "GUS WI will be filed" else "no GUS WI" end)),
+              blocks: [
+                {
+                  type: "section",
+                  text: {
+                    type: "mrkdwn",
+                    text: ("*<" + $pr_url + "|CAP PR #" + $pr_number + ">*\n" + $pr_title)
+                  }
+                },
+                {
+                  type: "section",
+                  fields: [
+                    { type: "mrkdwn", text: ("*App:*\n" + ($c.manifest.name // "unknown")) },
+                    { type: "mrkdwn", text: ("*Version:*\n" + ($c.manifest.version // "unknown")) },
+                    { type: "mrkdwn", text: ("*Domain:*\n" + ($c.domain // "unknown")) },
+                    { type: "mrkdwn", text: ("*ISV:*\n" + ($c.isv // "unknown")) },
+                    { type: "mrkdwn", text: ("*Author:*\n" + $c.author.login + " <" + ($c.author.email // "") + ">") },
+                    { type: "mrkdwn", text: ("*Internal:*\n" + yn($c.author.is_internal)) },
+                    { type: "mrkdwn", text: ("*New app:*\n" + yn($c.is_new_app)) },
+                    { type: "mrkdwn", text: ("*Will file GUS WI:*\n" + yn($c.will_file_gus_wi)) }
+                  ]
+                }
+              ]
+            }' > "$payload_file"
+
+          printf 'file=%s\n' "$payload_file" >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        id: send
+        if: steps.marker.outputs.already_notified == 'false'
+        uses: slackapi/slack-github-action@v1.27.0
+        with:
+          payload-file-path: ${{ steps.payload.outputs.file }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+      - name: Drop marker on the PR
+        if: >-
+          steps.marker.outputs.already_notified == 'false' &&
+          steps.send.conclusion == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          body_file="$RUNNER_TEMP/slack-marker.md"
+          {
+            printf '<!-- slack-cap-notify -->\n'
+            printf '_Notified Slack channel of this CAP PR._\n'
+          } > "$body_file"
+          gh api "repos/$REPO/issues/$PR_NUMBER/comments" -f body=@"$body_file"

--- a/docs/maintainer-setup.md
+++ b/docs/maintainer-setup.md
@@ -1,0 +1,119 @@
+# Maintainer setup
+
+Repo-scoped configuration only maintainers need. Contributors don't have to
+read this.
+
+## Required repository secrets
+
+The Commerce Apps CAP-PR automation depends on two secrets configured under
+**Settings → Secrets and variables → Actions** on this repository.
+
+| Secret | Consumed by | Purpose |
+|---|---|---|
+| `GUS_SFDX_AUTH_URL` | `.github/workflows/gus-security-review.yml` | Auth for the `sf` CLI against the GUS org so the workflow can create an `ADM_Work__c` record when an external contributor submits a net-new CAP. |
+| `SLACK_WEBHOOK_URL` | `.github/workflows/notify-slack-cap-pr.yml` | Incoming webhook that receives the CAP-PR canary message posted for every PR touching `**/*.zip`, regardless of author. |
+
+If either secret is missing the corresponding workflow logs a
+`::error::` line naming the missing secret and exits non-zero — the PR check
+turns red so a maintainer notices immediately.
+
+### 1. `GUS_SFDX_AUTH_URL`
+
+The value is a single-line `force://...` SFDX auth URL produced by the
+Salesforce CLI. It is bound to a specific service account and must be
+regenerated whenever that account's password / token rotates.
+
+**Generate:**
+
+```bash
+# One-time login on the maintainer's laptop against the GUS org that owns
+# the ADM_Work__c object.
+sf org login web \
+  --instance-url https://gus.my.salesforce.com \
+  --alias gus
+
+# Print the SFDX auth URL for the just-authenticated org. This is the value
+# to paste into the GitHub secret.
+sf org display --target-org gus --verbose --json \
+  | jq -r '.result.sfdxAuthUrl'
+```
+
+The workflow authenticates by writing the secret to a temp file and running
+`sf org login sfdx-url --sfdx-url-file <file>` — the auth URL never appears on
+a command line where a diagnostic dump could leak it into build logs.
+
+**Rotation:** rerun the two commands above and update the secret. There is no
+staged handoff; a stale value will surface as a red `Authenticate to GUS via
+sfdx-url` step in the next PR check.
+
+### 2. `SLACK_WEBHOOK_URL`
+
+An Incoming Webhook URL for the dedicated CAP-PR canary channel in the
+Salesforce.com Slack workspace.
+
+**Generate:**
+
+1. In the Salesforce.com Slack workspace, create (or reuse) a Slack App that
+   owns Incoming Webhooks (`https://api.slack.com/apps` → **Create New App**
+   → **From scratch**, name it e.g. `commerce-apps CAP-PR canary`).
+2. Under the app's **Incoming Webhooks** feature, toggle the feature on and
+   click **Add New Webhook to Workspace**. Select the target channel (a
+   dedicated CAP-PR canary channel — not `#general`).
+3. Copy the generated URL (`https://hooks.slack.com/services/...`) into the
+   `SLACK_WEBHOOK_URL` secret on this repository.
+
+The workflow posts payloads built with `jq --arg` / `--argjson`, so a hostile
+PR title or manifest field cannot break the JSON envelope or escape into
+Slack markup.
+
+**Rotation:** delete-and-recreate the webhook in the Slack app, then update
+the secret. Existing PR comments carrying the `<!-- slack-cap-notify -->`
+marker will keep the workflow idempotent through the transition.
+
+## Auto-filed GUS Work Items
+
+When the classifier at `.github/scripts/classify-cap-pr.sh` decides a PR is
+both **external-authored** and a **net-new** ISV directory,
+`gus-security-review.yml` creates one `ADM_Work__c` record under:
+
+- **Epic:** `C360 PSA: Commerce Apps - Submissions` (`a3QEE000002VGqX2AW`)
+- **Product Tag:** `a1aEE000001NDFJYA4`
+- **Scrum Team:** `a00EE00001Ux7RuYAJ`
+- **Assignee:** `005B0000006B9w0IAC`
+- **Record Type:** User Story (`0129000000006gDAAQ`)
+- **Priority:** P2
+
+Idempotency is enforced by the hidden HTML marker
+`<!-- gus-security-review-wi -->` in a PR comment: if the marker is already
+present, the workflow logs "already filed" and exits before touching GUS.
+
+The Slack canary uses the equivalent marker
+`<!-- slack-cap-notify -->` and posts exactly one message per PR even across
+`synchronize` events.
+
+## Why both workflows use `pull_request_target`
+
+External CAP submissions arrive from **forks**. Under GitHub's default
+`pull_request` trigger, fork-PR workflow runs get an empty `secrets.*`
+context and a read-only `GITHUB_TOKEN` — meaning neither the GUS auth
+step nor the Slack post nor the "drop idempotency marker" comment can
+succeed on the exact PRs these workflows exist to handle.
+
+Both workflows therefore trigger on `pull_request_target` and follow the
+**fetch-but-do-not-execute** pattern:
+
+1. Check out the base ref only (`ref: github.event.pull_request.base.sha`).
+   Every script that subsequently runs — `classify-cap-pr.sh`, the inline
+   `jq` payload builders, the Slack action reference — comes from the
+   trusted base commit, NOT from the PR head.
+2. `git fetch` the PR head into the object database
+   (`+refs/pull/N/head:refs/remotes/origin/pr/N`). The head commit is now
+   reachable for `git show HEAD_SHA:path` and `git diff BASE HEAD`, but
+   nothing from it lands on the working tree.
+3. The classifier reads the PR-head manifest via `git show`, never
+   `cat manifest.json`.
+
+**When modifying either workflow, do not add a `checkout` of `head.sha`
+or any step that pipes head-provided content into `bash` / `sh` / `node`
+/ `python` / etc.** Doing so would let a fork PR exfiltrate
+`GUS_SFDX_AUTH_URL` and `SLACK_WEBHOOK_URL`.


### PR DESCRIPTION
## Summary
- Cherry-picks the remaining commits on `main` not yet present on `release/26.8` (beyond the sf-payments app, which is covered by #61):
  - `#50` / `#55` (W-23544905): auto-file GUS security-review WIs for external CAP submissions, plus the follow-up that disables the auto-file until the Connected App is IP-relaxed.
  - `#54` (W-23563851): extend the CAP security scanner with S17/S18/S19 (WARN-level) checks.
- After this and #61 merge, `release/26.8` and `main` diverge only on the connection-health-check feature (W-22918563), which exists on `release/26.8` but not yet on `main` — the reverse direction, out of scope here.

## Test plan
- [x] Diffed the ported files against `main` — zero delta.
- [x] `bash .github/scripts/test-classify-cap-pr.sh` — 26 passed, 0 failed.
- [x] `bash .github/scripts/test-security-scan.sh` — 129 passed, 0 failed.