### PR TITLE
@W-23543664: Fix promote-forward checkout target (exit 128) + align manifest indentation

### DIFF
--- a/.github/scripts/promotion-utils.sh
+++ b/.github/scripts/promotion-utils.sh
@@ -108,7 +108,10 @@ merge_manifest_entry() {
   local entry_json="${2:?entry JSON is required}"
   local category="${3:?category is required}"
 
-  jq --argjson entry "$entry_json" --arg cat "$category" '
+  # The committed manifest.json uses 4-space indentation, so pass --indent 4
+  # to keep the upsert a minimal diff (just the changed entry) instead of
+  # reformatting the whole file to jq's 2-space default on every promotion.
+  jq --indent 4 --argjson entry "$entry_json" --arg cat "$category" '
     def mmp($s): ($s | split("-")[0] | split(".") | map(tonumber));
     def rank($s): (if ($s | test("-")) then 0 else 1 end);
     # Compare two semver strings: 1 if a>b, 0 if equal, -1 if a<b.

--- a/.github/scripts/test-promotion-utils.sh
+++ b/.github/scripts/test-promotion-utils.sh
@@ -175,6 +175,15 @@ assert_json_eq "creates missing category" \
   '{"defaultLocale":"en","tax":[{"id":"t","zip":"t-v1.0.0.zip","version":"1.0.0"}],"analytics":[{"id":"n","zip":"n-v1.0.0.zip","version":"1.0.0"}]}' \
   merge_manifest_entry "$m3" '{"id":"n","zip":"n-v1.0.0.zip","version":"1.0.0"}' "analytics"
 
+# The committed manifest.json is 4-space indented; the upsert MUST preserve that
+# so a promotion produces a minimal diff instead of reformatting the whole file.
+# assert_json_eq above canonicalizes whitespace and cannot catch this, so assert
+# the raw indentation of a nested key directly.
+m4="$(mkfile '{"analytics":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}')"
+m4_indent="$(merge_manifest_entry "$m4" '{"id":"b","zip":"b-v1.0.0.zip","version":"1.0.0"}' "analytics" \
+  | grep -m1 '"analytics"' | sed -E 's/[^ ].*//' | tr -d '\n' | wc -c | tr -d ' ')"
+assert_eq "upsert emits 4-space indentation" "4" printf '%s' "$m4_indent"
+
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -310,8 +310,14 @@ jobs:
           fi
 
           # 4) Switch to the target branch working tree.
+          #
+          # Check out a LOCAL branch named after the target ($next) tracking its
+          # real origin ref, NOT a throwaway name. create-pull-request treats the
+          # checked-out branch as its "working base" and, during cleanup, runs
+          # `git reset --hard origin/<checked-out-branch>`; a phantom name like
+          # `promote-work` has no origin ref and that reset aborts the action.
           git fetch origin "+refs/heads/$next:refs/remotes/origin/$next"
-          git checkout -B promote-work "origin/$next"
+          git checkout -B "$next" "origin/$next"
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## What

The \`promote-forward\` job checked out a throwaway local branch \`promote-work\` before handing off to \`peter-evans/create-pull-request\`. That action treats the currently checked-out branch as its **working base** and, during cleanup, runs \`git reset --hard origin/<checked-out-branch>\`. Since \`origin/promote-work\` never exists, the reset aborts with **exit 128** and the promotion PR is never opened.

## Fix

Check out a local branch named after the target (\`$next\`) tracking its real origin ref instead of a phantom name:

\`\`\`diff
-          git checkout -B promote-work "origin/$next"
+          git checkout -B "$next" "origin/$next"
\`\`\`

This is the same one-line change (plus an explanatory comment) that has been running green in the `shauryemahajanSF/registry-testing` test fork release branches.

## Why it surfaced now

The bug is only reachable via the forward-integration cascade (`promote-forward` job on `release/**`), introduced in #58/#59/#60. It broke [run 30471869251](https://github.com/SalesforceCommerceCloud/commerce-apps/actions/runs/30471869251) when sf-payments v1.0.1 tried to promote 26.8 → 26.9.

## Rollout note

The three prod branches (`main`, `release/26.8`, `release/26.9`) already carry the tolerant `lookup_manifest_entry_for_zip` skip fix (from #59/#60); this PR is byte-identical across all three and completes the fix. On `main` the `promote-forward` job is gated off (`startsWith(ref, 'release/')`), so this is a parity change there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)