### PR TITLE
@W-23651027: Enforce SFRA-requires-SFNext in verify-zip.yml CI validation

### DIFF
--- a/.github/scripts/root-manifest-utils.sh
+++ b/.github/scripts/root-manifest-utils.sh
@@ -51,6 +51,25 @@ validate_manifest() {
   fi
 }
 
+# SFRA is additive-only to SFNext: rejects storefrontSupport.sfra declared
+# without a storefrontSupport.sfnext.minVersion alongside it.
+validate_sfra_requires_sfnext() {
+  local entry_json="${1:?JSON object is required}"
+  local context="${2:-storefrontSupport}"
+  local file="${3:-}"
+
+  local has_sfra
+  has_sfra="$(jq -r '(.storefrontSupport // {}) | has("sfra")' <<< "$entry_json")"
+  [[ "$has_sfra" == "true" ]] || return 0
+
+  local sfnext_min_version
+  sfnext_min_version="$(jq -r '.storefrontSupport.sfnext.minVersion // empty' <<< "$entry_json")"
+  if [[ -z "$sfnext_min_version" ]]; then
+    echo "::error file=$file::storefrontSupport.sfra declared without storefrontSupport.sfnext.minVersion in $context (SFRA is additive-only to SFNext)"
+    return 1
+  fi
+}
+
 # Returns exactly one matching manifest entry JSON object for zip filename.
 get_manifest_entry_for_zip() {
   local zip_file="${1:?zip filename is required}"

--- a/.github/scripts/test-root-manifest-utils.sh
+++ b/.github/scripts/test-root-manifest-utils.sh
@@ -85,6 +85,28 @@ assert_fail  "just text: abc"              validate_semver "abc"
 echo ""
 
 # ---------------------------------------------------------------------------
+# validate_sfra_requires_sfnext
+# ---------------------------------------------------------------------------
+echo "--- validate_sfra_requires_sfnext ---"
+
+assert_pass  "no storefrontSupport at all" \
+  validate_sfra_requires_sfnext '{}'
+
+assert_pass  "sfnext alone" \
+  validate_sfra_requires_sfnext '{"storefrontSupport":{"sfnext":{"minVersion":"1.0.0"}}}'
+
+assert_pass  "sfnext and sfra together" \
+  validate_sfra_requires_sfnext '{"storefrontSupport":{"sfnext":{"minVersion":"1.0.0"},"sfra":{"minVersion":"2.0.0"}}}'
+
+assert_fail  "sfra without sfnext" \
+  validate_sfra_requires_sfnext '{"storefrontSupport":{"sfra":{"minVersion":"2.0.0"}}}'
+
+assert_fail  "sfra with sfnext present but no minVersion" \
+  validate_sfra_requires_sfnext '{"storefrontSupport":{"sfnext":{},"sfra":{"minVersion":"2.0.0"}}}'
+
+echo ""
+
+# ---------------------------------------------------------------------------
 # validate_manifest
 # ---------------------------------------------------------------------------
 echo "--- validate_manifest ---"

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -467,6 +467,19 @@ jobs:
               done
             done
 
+            # SFRA is additive-only to SFNext: reject sfra declared without sfnext,
+            # checked on both the manifest entry and the extracted commerce-app.json.
+            if ! validate_sfra_requires_sfnext "$entry" "manifest entry for $zip_file" "$manifest_path"; then
+              rm -rf "$tmpdir"
+              exit 1
+            fi
+            if [[ -n "$commerce_app" && -f "$commerce_app" ]]; then
+              if ! validate_sfra_requires_sfnext "$(cat "$commerce_app")" "commerce-app.json for $zip_file" "$manifest_path"; then
+                rm -rf "$tmpdir"
+                exit 1
+              fi
+            fi
+
             # Cross-validate every storefrontSupport min/max value between manifest and commerce-app.json.
             for storefront in sfnext sfra; do
               for field in minVersion maxVersion; do


### PR DESCRIPTION
## Summary
- Adds a check to Step 8 of `.github/workflows/verify-zip.yml` that fails the build with an `::error` annotation if `storefrontSupport.sfra` is declared without `storefrontSupport.sfnext.minVersion`, applied to both the manifest entry and the extracted `commerce-app.json`.
- Implements the check as `validate_sfra_requires_sfnext` in `.github/scripts/root-manifest-utils.sh`, following the existing pattern in that step (`jq -r ... has(...)`, `::error file=$manifest_path::...`, `rm -rf "$tmpdir"`, `exit 1`).
- Closes the enforcement gap left by PR #71: a contributor editing `manifest.json` directly (bypassing the Claude Code skills) could previously still merge an SFRA-only app despite the "SFRA is additive-only to SFNext" policy now documented in `CONTRIBUTING.md`/`AGENTS.md`.

## Test plan
- [x] `bash .github/scripts/run-all-tests.sh` — 7/7 suites passing (added `validate_sfra_requires_sfnext` cases to `test-root-manifest-utils.sh`: no storefrontSupport, sfnext alone, sfnext+sfra together, sfra without sfnext, sfra with empty sfnext)
- [x] Manually extracted and ran Step 8's actual bash body against three synthetic zip fixtures: sfra-only → correctly fails with `::error` annotation naming the zip; sfnext-only → passes; sfnext+sfra together → passes
- [x] Confirmed no existing `commerce-apps-manifest/manifest.json` entries declare `storefrontSupport` (nothing to regress)
- [x] `/review-swarm`-style review pass — no correctness issues found
- [x] Gap-finder conformance pass against all 4 W-23651027 acceptance criteria — all MET

🤖 Generated with [Claude Code](https://claude.com/claude-code)