### PR TITLE
@W-23651027: Forward-port non-CAP promotion + SFRA-requires-SFNext to release/26.8

### DIFF
--- a/.github/scripts/promotion-utils.sh
+++ b/.github/scripts/promotion-utils.sh
@@ -125,8 +125,16 @@ merge_manifest_entry() {
     | if $existing == null then
         # New app on this target -> append.
         .[$cat] = ($arr + [$entry])
+      elif ($existing == $entry) then
+        # Byte-for-byte identical already -> true no-op. Without this branch,
+        # the "replace" branch below would still fire (equal version compares
+        # >= 0) and re-append the entry at the end of the array, reordering
+        # every other promoted entry for zero effect and producing a
+        # spurious diff on an otherwise fully-idempotent re-promotion.
+        .
       elif (semver_cmp($entry.version; ($existing.version // "0.0.0")) >= 0) then
-        # Incoming version is newer or equal -> replace the pinned entry.
+        # Incoming version is newer, or equal but with changed metadata ->
+        # replace the pinned entry.
         .[$cat] = ((($arr | map(select((.id? // "") != $id)))) + [$entry])
       else
         # Target already pins a newer version -> leave it untouched (monotonic).
@@ -134,3 +142,147 @@ merge_manifest_entry() {
       end
   ' "$manifest_path"
 }
+
+# Merges every entry across every category of a source manifest.json into a
+# target manifest.json, applying the same per-id monotonic upsert as
+# merge_manifest_entry (above) to each entry individually. This is what lets a
+# manual, hand-edited manifest.json change (not tied to any ZIP push) promote
+# forward: the edited entry is MERGED into the target - respecting the
+# monotonic, id-keyed guard - rather than the whole file being overwritten,
+# so it can never regress an entry the target already pins to a newer version.
+#
+# A single malformed entry (e.g. a non-semver version string) must not abort
+# the whole merge under the caller's `set -e` - that would silently discard
+# every entry already merged earlier in the loop. So each entry's upsert is
+# guarded individually: on failure, that one entry is skipped (with a
+# `::warning::` naming it) and every other entry still merges normally.
+#
+# Top-level fields that are NOT category arrays (e.g. `defaultLocale`) have no
+# per-entry version to compare, so there is no monotonic ordering to preserve;
+# a manual edit to one of those fields simply carries forward verbatim.
+#
+#   merge_manifest_file <target_manifest_path> <source_manifest_path>
+merge_manifest_file() {
+  local target_path="${1:?target manifest path is required}"
+  local source_path="${2:?source manifest path is required}"
+
+  local categories
+  categories="$(jq -r 'to_entries[] | select(.value | type == "array") | .key' "$source_path")"
+
+  local current="$target_path"
+  local cat entries entry tmp entry_id
+  while IFS= read -r cat; do
+    [[ -z "$cat" ]] && continue
+    entries="$(jq -c --arg c "$cat" '.[$c][]' "$source_path")"
+    while IFS= read -r entry; do
+      [[ -z "$entry" ]] && continue
+      tmp="$(mktemp)"
+      if merge_manifest_entry "$current" "$entry" "$cat" > "$tmp" 2>/dev/null; then
+        [[ "$current" != "$target_path" ]] && rm -f "$current"
+        current="$tmp"
+      else
+        entry_id="$(jq -r '.id // "<unknown>"' <<< "$entry" 2>/dev/null)"
+        echo "::warning::Skipping malformed manifest entry '$entry_id' in category '$cat' (failed to merge); leaving target unchanged for this entry." >&2
+        rm -f "$tmp"
+      fi
+    done <<< "$entries"
+  done <<< "$categories"
+
+  jq --slurpfile s "$source_path" '
+    reduce ($s[0] | to_entries[] | select(.value | type != "array")) as $e (.; .[$e.key] = $e.value)
+  ' "$current"
+  [[ "$current" != "$target_path" ]] && rm -f "$current"
+}
+
+# Merges a translations locale file (commerce-apps-manifest/translations/*.json
+# - a flat object keyed by app id, e.g. {"salesforce-flat-tax": {"name": ...,
+# "description": ...}}) additively: keys already present on the target are
+# left untouched (so this can never regress an intentional target-only
+# translation edit), and keys present only in the source are added. There is
+# no version to compare (translation entries aren't versioned), so "monotonic"
+# here means "never overwrite an existing target key", not semver ordering.
+#
+#   merge_translations_file <target_locale_path> <source_locale_path>
+merge_translations_file() {
+  local target_path="${1:?target locale path is required}"
+  local source_path="${2:?source locale path is required}"
+
+  jq --slurpfile s "$source_path" '
+    reduce ($s[0] | to_entries[]) as $e (.; if has($e.key) then . else .[$e.key] = $e.value end)
+  ' "$target_path"
+}
+
+# Applies a non-CAP file-content patch (a `git diff --binary` between two
+# commits, scoped to a SINGLE file - see NON_CAP_PATHSPEC below) onto the
+# current working tree/index. The caller must build one patch per changed
+# file (not one combined patch for the whole push): git apply/reverse-check
+# treat a patch as all-or-nothing, so a single conflicting or binary file
+# bundled into one combined patch would cause every OTHER, unrelated file in
+# that same patch to be skipped too. `--binary` on the diff side is required
+# so a binary file's hunk carries literal patch data instead of rendering as
+# an unapplyable "Binary files ... differ" placeholder.
+#
+# Non-CAP files are plain content, not a monotonic merge like the
+# catalog/manifest, so re-promotion must stay idempotent and must never
+# clobber intentional per-branch divergence:
+#   - empty patch                              -> "no-op"   (nothing to do)
+#   - applies cleanly                          -> "applied" (staged via -index)
+#   - already present on target (reverse-check succeeds) -> "no-op" (idempotent)
+#   - genuine conflict with target-only changes -> "skipped" (never force it)
+# All three non-error outcomes return 0 so the caller can keep promoting the
+# rest of the change (CAP artifacts, manifest) even when the non-CAP patch is
+# skipped; only a real git failure propagates a non-zero exit.
+#
+#   apply_non_cap_patch <patch_file>
+apply_non_cap_patch() {
+  local patch_file="${1:?patch file is required}"
+
+  if [[ ! -s "$patch_file" ]]; then
+    echo "no-op"
+    return 0
+  fi
+
+  if git apply --check "$patch_file" 2>/dev/null; then
+    git apply --index "$patch_file"
+    echo "applied"
+    return 0
+  fi
+
+  if git apply --reverse --check "$patch_file" 2>/dev/null; then
+    echo "no-op"
+    return 0
+  fi
+
+  echo "::warning::Non-CAP patch does not apply cleanly onto the target branch (likely per-branch divergence); skipping non-CAP file promotion this round." >&2
+  echo "skipped"
+  return 0
+}
+
+# The non-CAP pathspec: every tracked file EXCEPT the artifacts already owned
+# by the CAP promotion path (ZIPs, their sibling catalog.json, extracted
+# icons), manifest.json (promoted via merge_manifest_file, a monotonic
+# per-entry merge), and the translations locale files (promoted via
+# merge_translations_file, an additive per-key merge) - none of those are
+# plain file copies, so none belong on the generic patch-apply path. Each is
+# keyed content (by app id) that two branches can independently and
+# non-conflictingly add to at the same point in the file, which is exactly
+# the shape a single git-diff patch handles poorly (see apply_non_cap_patch).
+#
+# .github/workflows/** is also excluded: the promotion PR is pushed with the
+# default GITHUB_TOKEN, and GitHub hard-blocks any token-driven push that adds
+# or modifies a workflow file unless the token holds the `workflows`
+# permission - a permission `GITHUB_TOKEN` can never be granted via the
+# `permissions:` block. Promoting a workflow change would fail PR creation
+# outright, not just skip harmlessly, so it is excluded rather than attempted.
+#
+# Anything else - docs/**, skills, READMEs, other config - is eligible for
+# plain-content forward promotion.
+NON_CAP_PATHSPEC=(
+  '.'
+  ':(exclude,glob)**/*.zip'
+  ':(exclude,glob)**/catalog.json'
+  ':(exclude,glob)commerce-apps-manifest/icons/**'
+  ':(exclude)commerce-apps-manifest/manifest.json'
+  ':(exclude,glob)commerce-apps-manifest/translations/**'
+  ':(exclude,glob).github/workflows/**'
+)

--- a/.github/scripts/root-manifest-utils.sh
+++ b/.github/scripts/root-manifest-utils.sh
@@ -51,6 +51,25 @@ validate_manifest() {
   fi
 }
 
+# SFRA is additive-only to SFNext: rejects storefrontSupport.sfra declared
+# without a storefrontSupport.sfnext.minVersion alongside it.
+validate_sfra_requires_sfnext() {
+  local entry_json="${1:?JSON object is required}"
+  local context="${2:-storefrontSupport}"
+  local file="${3:-}"
+
+  local has_sfra
+  has_sfra="$(jq -r '(.storefrontSupport // {}) | has("sfra")' <<< "$entry_json")"
+  [[ "$has_sfra" == "true" ]] || return 0
+
+  local sfnext_min_version
+  sfnext_min_version="$(jq -r '.storefrontSupport.sfnext.minVersion // empty' <<< "$entry_json")"
+  if [[ -z "$sfnext_min_version" ]]; then
+    echo "::error file=$file::storefrontSupport.sfra declared without storefrontSupport.sfnext.minVersion in $context (SFRA is additive-only to SFNext)"
+    return 1
+  fi
+}
+
 # Returns exactly one matching manifest entry JSON object for zip filename.
 get_manifest_entry_for_zip() {
   local zip_file="${1:?zip filename is required}"

--- a/.github/scripts/test-promotion-utils.sh
+++ b/.github/scripts/test-promotion-utils.sh
@@ -57,10 +57,14 @@ assert_fails() {
   fi
 }
 
-_FC=0
 mkfile() {
-  _FC=$((_FC + 1))
-  local f="$TMPDIR_ROOT/file_${_FC}.json"
+  # mktemp (not a shared counter) so each call yields a distinct path even
+  # though mkfile always runs in a subshell via $(mkfile ...) - a counter
+  # variable's increment can't survive back to the parent shell, so every
+  # call would otherwise collide on the same path (silently breaking any
+  # test that needs two live files at once, e.g. a target + a source).
+  local f
+  f="$(mktemp "$TMPDIR_ROOT/file.XXXXXX")"
   printf '%s\n' "$1" > "$f"
   printf '%s' "$f"
 }
@@ -184,6 +188,17 @@ m4_indent="$(merge_manifest_entry "$m4" '{"id":"b","zip":"b-v1.0.0.zip","version
   | grep -m1 '"analytics"' | sed -E 's/[^ ].*//' | tr -d '\n' | wc -c | tr -d ' ')"
 assert_eq "upsert emits 4-space indentation" "4" printf '%s' "$m4_indent"
 
+# Byte-identical re-upsert must be a true no-op: it must NOT move the entry to
+# the end of its category array (which would happen if the equal-version
+# "replace" branch fired), or every other entry's promotion would be reordered
+# for zero effect on a fully-idempotent re-promotion.
+m5="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"},{"id":"b","zip":"b-v1.0.0.zip","version":"1.0.0"}]}')"
+assert_json_eq "byte-identical re-upsert does not reorder" \
+  '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"},{"id":"b","zip":"b-v1.0.0.zip","version":"1.0.0"}]}' \
+  merge_manifest_entry "$m5" '{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}' "shipping"
+m5_order="$(merge_manifest_entry "$m5" '{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}' "shipping" | jq -r '.shipping[0].id')"
+assert_eq "byte-identical re-upsert keeps original position" "a" printf '%s' "$m5_order"
+
 echo ""
 
 # ---------------------------------------------------------------------------
@@ -234,6 +249,239 @@ if [[ "$dup_err" == *"Multiple manifest entries"* ]]; then
   PASS=$((PASS + 1))
 else
   echo "  FAIL: duplicate error not on stderr"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# merge_manifest_file (whole-manifest merge for manual manifest.json edits
+# promoted with no ZIP)
+# ---------------------------------------------------------------------------
+echo "--- merge_manifest_file ---"
+
+# Source has a newer entry for an app the target already pins -> replaces it,
+# same monotonic guard as merge_manifest_entry, applied across every category.
+mf1_target="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}')"
+mf1_source="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.1.0.zip","version":"1.1.0"}]}')"
+assert_json_eq "newer entry from source replaces target's pin" \
+  '{"shipping":[{"id":"a","zip":"a-v1.1.0.zip","version":"1.1.0"}]}' \
+  merge_manifest_file "$mf1_target" "$mf1_source"
+
+# Source has an OLDER entry than target already pins -> target wins (monotonic).
+mf2_target="$(mkfile '{"shipping":[{"id":"a","zip":"a-v2.0.0.zip","version":"2.0.0"}]}')"
+mf2_source="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}')"
+assert_json_eq "older source entry does not regress target's pin" \
+  '{"shipping":[{"id":"a","zip":"a-v2.0.0.zip","version":"2.0.0"}]}' \
+  merge_manifest_file "$mf2_target" "$mf2_source"
+
+# Source introduces a brand-new app in an existing category -> appended.
+mf3_target="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}')"
+mf3_source="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}],"tax":[{"id":"t","zip":"t-v1.0.0.zip","version":"1.0.0"}]}')"
+assert_json_eq "new category/app from source is added" \
+  '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}],"tax":[{"id":"t","zip":"t-v1.0.0.zip","version":"1.0.0"}]}' \
+  merge_manifest_file "$mf3_target" "$mf3_source"
+
+# Re-merging the same source into an already-merged target is idempotent.
+mf4_target="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.1.0.zip","version":"1.1.0"}]}')"
+mf4_source="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.1.0.zip","version":"1.1.0"}]}')"
+assert_json_eq "idempotent re-merge (no dup)" \
+  '{"shipping":[{"id":"a","zip":"a-v1.1.0.zip","version":"1.1.0"}]}' \
+  merge_manifest_file "$mf4_target" "$mf4_source"
+
+# A scalar top-level field (e.g. defaultLocale) has no per-entry version to
+# compare, so it must still carry forward verbatim rather than being silently
+# dropped by a merge that only knows how to walk category arrays.
+mf5_target="$(mkfile '{"defaultLocale":"en","shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}')"
+mf5_source="$(mkfile '{"defaultLocale":"fr","shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}')"
+assert_json_eq "scalar field carries forward from source" \
+  '{"defaultLocale":"fr","shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}]}' \
+  merge_manifest_file "$mf5_target" "$mf5_source"
+
+# A single malformed entry (e.g. missing/non-semver version) must not abort the
+# whole merge under `set -e` - every other, well-formed entry in the same
+# source manifest still merges normally.
+mf6_target="$(mkfile '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}],"tax":[{"id":"t","zip":"t-v1.0.0.zip","version":"1.0.0"}]}')"
+mf6_source="$(mkfile '{"shipping":[{"id":"a","zip":"a-vBAD.zip","version":"not-a-semver"}],"tax":[{"id":"t","zip":"t-v1.1.0.zip","version":"1.1.0"}]}')"
+assert_json_eq "malformed entry is skipped, other entries still merge" \
+  '{"shipping":[{"id":"a","zip":"a-v1.0.0.zip","version":"1.0.0"}],"tax":[{"id":"t","zip":"t-v1.1.0.zip","version":"1.1.0"}]}' \
+  merge_manifest_file "$mf6_target" "$mf6_source"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# merge_translations_file (additive per-key merge for locale files)
+# ---------------------------------------------------------------------------
+echo "--- merge_translations_file ---"
+
+# New app id in source, absent on target -> added.
+tr1_target="$(mkfile '{"app-a":{"name":"App A","description":"desc a"}}')"
+tr1_source="$(mkfile '{"app-b":{"name":"App B","description":"desc b"}}')"
+assert_json_eq "adds new app id from source" \
+  '{"app-a":{"name":"App A","description":"desc a"},"app-b":{"name":"App B","description":"desc b"}}' \
+  merge_translations_file "$tr1_target" "$tr1_source"
+
+# App id present on both, with different content -> target's key wins
+# (additive-only: never overwrite an existing target key).
+tr2_target="$(mkfile '{"app-a":{"name":"Target Name","description":"target desc"}}')"
+tr2_source="$(mkfile '{"app-a":{"name":"Source Name","description":"source desc"}}')"
+assert_json_eq "existing target key is never overwritten" \
+  '{"app-a":{"name":"Target Name","description":"target desc"}}' \
+  merge_translations_file "$tr2_target" "$tr2_source"
+
+# Re-merging the same source is idempotent (no change on second pass).
+tr3_target="$(mkfile '{"app-a":{"name":"App A","description":"desc a"}}')"
+tr3_source="$(mkfile '{"app-b":{"name":"App B","description":"desc b"}}')"
+merge_translations_file "$tr3_target" "$tr3_source" > "$tr3_target.tmp1"
+assert_json_eq "idempotent re-merge (no dup/no change)" \
+  '{"app-a":{"name":"App A","description":"desc a"},"app-b":{"name":"App B","description":"desc b"}}' \
+  merge_translations_file "$tr3_target.tmp1" "$tr3_source"
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# apply_non_cap_patch (plain-content promotion for docs/skills/.github/etc.)
+# ---------------------------------------------------------------------------
+echo "--- apply_non_cap_patch ---"
+
+# Empty patch (no non-CAP files changed) -> no-op, exit 0.
+empty_patch="$(mkfile '')"
+: > "$empty_patch"
+assert_eq "empty patch is a no-op" "no-op" apply_non_cap_patch "$empty_patch"
+
+# A patch that applies cleanly onto the current working tree -> "applied",
+# and the file content changes and is staged.
+np_dir="$(mktemp -d -p "$TMPDIR_ROOT")"
+(
+  cd "$np_dir"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  mkdir -p docs
+  printf 'line1\n' > docs/readme.md
+  git add -A && git commit -qm init
+  before="$(git rev-parse HEAD)"
+  printf 'line1\nline2\n' > docs/readme.md
+  git add -A && git commit -qm change
+  after="$(git rev-parse HEAD)"
+  git diff "$before" "$after" -- docs/readme.md > "$TMPDIR_ROOT/apply.patch"
+  git checkout -q "$before" -- docs/readme.md
+)
+result="$(cd "$np_dir" && apply_non_cap_patch "$TMPDIR_ROOT/apply.patch")"
+assert_eq "clean patch applies" "applied" printf '%s' "$result"
+applied_content="$(cat "$np_dir/docs/readme.md")"
+assert_eq "applied patch content matches" "$(printf 'line1\nline2')" printf '%s' "$applied_content"
+
+# Re-applying the SAME patch onto a tree that already has the change
+# (reverse-check succeeds) -> idempotent no-op, not an error and not a
+# duplicate/conflicting apply.
+result2="$(cd "$np_dir" && apply_non_cap_patch "$TMPDIR_ROOT/apply.patch")"
+assert_eq "already-applied patch is idempotent no-op" "no-op" printf '%s' "$result2"
+
+# A patch that conflicts with intentional target-only divergence -> skipped,
+# never forced, and does not abort the caller (still exit 0).
+conflict_dir="$(mktemp -d -p "$TMPDIR_ROOT")"
+(
+  cd "$conflict_dir"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  mkdir -p docs
+  printf 'shared-base\n' > docs/readme.md
+  git add -A && git commit -qm init
+  # Target-only divergence: a change the patch does not know about, on the
+  # exact same line the (unrelated) source-side patch also touches.
+  printf 'target-only-change\n' > docs/readme.md
+  git add -A && git commit -qm "target diverges"
+)
+conflict_result="$(cd "$conflict_dir" && apply_non_cap_patch "$TMPDIR_ROOT/apply.patch")"
+assert_eq "conflicting patch is skipped, not forced" "skipped" printf '%s' "$conflict_result"
+conflict_content="$(cat "$conflict_dir/docs/readme.md")"
+assert_eq "target-only divergence is preserved on skip" "target-only-change" printf '%s' "$conflict_content"
+
+# A patch that ADDS a brand-new file (source created it, target never had it)
+# must apply and stage the new file, not just modify existing content.
+add_dir="$(mktemp -d -p "$TMPDIR_ROOT")"
+(
+  cd "$add_dir"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  printf 'seed\n' > seed.txt
+  git add -A && git commit -qm init
+  before="$(git rev-parse HEAD)"
+  mkdir -p docs
+  printf 'new file\n' > docs/new.md
+  git add -A && git commit -qm add
+  after="$(git rev-parse HEAD)"
+  git diff --binary "$before" "$after" -- docs/new.md > "$TMPDIR_ROOT/add.patch"
+  git reset --hard -q "$before"
+)
+add_result="$(cd "$add_dir" && apply_non_cap_patch "$TMPDIR_ROOT/add.patch")"
+assert_eq "patch adding a new file applies" "applied" printf '%s' "$add_result"
+assert_eq "new file content matches" "new file" printf '%s' "$(cat "$add_dir/docs/new.md")"
+
+# A patch that DELETES a file (present on target, removed on source) must
+# apply and stage the deletion, not error.
+del_dir="$(mktemp -d -p "$TMPDIR_ROOT")"
+(
+  cd "$del_dir"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  mkdir -p docs
+  printf 'to be removed\n' > docs/gone.md
+  git add -A && git commit -qm init
+  before="$(git rev-parse HEAD)"
+  git rm -q docs/gone.md
+  git commit -qm remove
+  after="$(git rev-parse HEAD)"
+  git diff --binary "$before" "$after" -- docs/gone.md > "$TMPDIR_ROOT/del.patch"
+  git checkout -q "$before" -- docs/gone.md
+)
+del_result="$(cd "$del_dir" && apply_non_cap_patch "$TMPDIR_ROOT/del.patch")"
+assert_eq "patch deleting a file applies" "applied" printf '%s' "$del_result"
+if [[ ! -f "$del_dir/docs/gone.md" ]]; then
+  echo "  PASS: deleted file removed from working tree"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: deleted file removed from working tree"
+  FAIL=$((FAIL + 1))
+fi
+
+echo ""
+
+# ---------------------------------------------------------------------------
+# NON_CAP_PATHSPEC
+# ---------------------------------------------------------------------------
+echo "--- NON_CAP_PATHSPEC ---"
+
+pathspec_dir="$(mktemp -d -p "$TMPDIR_ROOT")"
+(
+  cd "$pathspec_dir"
+  git init -q
+  git config user.email test@example.com
+  git config user.name test
+  mkdir -p .github/workflows docs commerce-apps-manifest/translations
+  printf 'a\n' > .github/workflows/ci.yml
+  printf 'b\n' > docs/readme.md
+  printf '{}\n' > commerce-apps-manifest/manifest.json
+  printf '{}\n' > commerce-apps-manifest/translations/en.json
+  git add -A && git commit -qm init
+)
+non_cap_out="$(cd "$pathspec_dir" && git ls-files -- "${NON_CAP_PATHSPEC[@]}")"
+if grep -qx '.github/workflows/ci.yml' <<< "$non_cap_out"; then
+  echo "  FAIL: .github/workflows/** excluded from NON_CAP_PATHSPEC"
+  FAIL=$((FAIL + 1))
+else
+  echo "  PASS: .github/workflows/** excluded from NON_CAP_PATHSPEC"
+  PASS=$((PASS + 1))
+fi
+if grep -qx 'docs/readme.md' <<< "$non_cap_out"; then
+  echo "  PASS: plain docs file included in NON_CAP_PATHSPEC"
+  PASS=$((PASS + 1))
+else
+  echo "  FAIL: plain docs file included in NON_CAP_PATHSPEC"
   FAIL=$((FAIL + 1))
 fi
 

--- a/.github/scripts/test-root-manifest-utils.sh
+++ b/.github/scripts/test-root-manifest-utils.sh
@@ -85,6 +85,28 @@ assert_fail  "just text: abc"              validate_semver "abc"
 echo ""
 
 # ---------------------------------------------------------------------------
+# validate_sfra_requires_sfnext
+# ---------------------------------------------------------------------------
+echo "--- validate_sfra_requires_sfnext ---"
+
+assert_pass  "no storefrontSupport at all" \
+  validate_sfra_requires_sfnext '{}'
+
+assert_pass  "sfnext alone" \
+  validate_sfra_requires_sfnext '{"storefrontSupport":{"sfnext":{"minVersion":"1.0.0"}}}'
+
+assert_pass  "sfnext and sfra together" \
+  validate_sfra_requires_sfnext '{"storefrontSupport":{"sfnext":{"minVersion":"1.0.0"},"sfra":{"minVersion":"2.0.0"}}}'
+
+assert_fail  "sfra without sfnext" \
+  validate_sfra_requires_sfnext '{"storefrontSupport":{"sfra":{"minVersion":"2.0.0"}}}'
+
+assert_fail  "sfra with sfnext present but no minVersion" \
+  validate_sfra_requires_sfnext '{"storefrontSupport":{"sfnext":{},"sfra":{"minVersion":"2.0.0"}}}'
+
+echo ""
+
+# ---------------------------------------------------------------------------
 # validate_manifest
 # ---------------------------------------------------------------------------
 echo "--- validate_manifest ---"

--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -5,8 +5,11 @@ on:
     branches:
       - main
       - 'release/**'
-    paths:
-      - '**/*.zip'
+    # No `paths` filter: `update-catalog-pr` only acts on changed ZIPs and
+    # no-ops otherwise, but `promote-forward` also carries non-CAP file
+    # changes (docs, skills, manifest.json edits) forward across release
+    # branches, so the workflow must fire on those pushes too. Each job below
+    # no-ops on its own when nothing relevant changed.
 
 permissions:
   contents: write
@@ -32,15 +35,21 @@ jobs:
           source ".github/scripts/root-manifest-utils.sh"
           source ".github/scripts/promotion-utils.sh"
           manifest_path="commerce-apps-manifest/manifest.json"
-          validate_manifest "$manifest_path"
 
-          # 1) Find ZIP files changed in this push to the target branch (merge commit)
+          # 1) Find ZIP files changed in this push to the target branch (merge commit).
+          #    Checked BEFORE validate_manifest: this job has nothing to do when no
+          #    ZIP changed, so an unrelated push (docs/skills/workflow-only) must not
+          #    be blocked by a pre-existing manifest defect it never touches - the
+          #    workflow now fires on every push (see the `on.push` comment above),
+          #    not just ZIP-touching ones.
           mapfile -t changed_zips < <(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- '**/*.zip')
 
           if [[ ${#changed_zips[@]} -eq 0 ]]; then
             echo "No .zip files changed. Exiting."
             exit 0
           fi
+
+          validate_manifest "$manifest_path"
 
           echo "Changed ZIPs:"
           printf ' - %s\n' "${changed_zips[@]}"
@@ -232,23 +241,58 @@ jobs:
           source ".github/scripts/root-manifest-utils.sh"
           source ".github/scripts/promotion-utils.sh"
           manifest_path="commerce-apps-manifest/manifest.json"
-          validate_manifest "$manifest_path"
 
-          # 1) ZIPs changed by this push (the merge commit on the source branch).
-          #    On branch creation github.event.before is all-zeros and there is
-          #    no real "before" commit to diff against; skip rather than promote
-          #    a whole branch's worth of artifacts on its first push.
+          # 1) What changed in this push (the merge commit on the source
+          #    branch). On branch creation github.event.before is all-zeros and
+          #    there is no real "before" commit to diff against; skip rather
+          #    than promote a whole branch's worth of history on its first push.
           if [[ "$BEFORE_SHA" =~ ^0+$ ]]; then
             echo "Branch-creation push (no prior commit); nothing to promote."
             echo "promote=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           mapfile -t changed_zips < <(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- '**/*.zip')
-          if [[ ${#changed_zips[@]} -eq 0 ]]; then
-            echo "No .zip files changed. Nothing to promote."
+          manifest_changed=false
+          if ! git diff --quiet "$BEFORE_SHA" "$AFTER_SHA" -- "$manifest_path"; then
+            manifest_changed=true
+          fi
+          translations_changed=false
+          if ! git diff --quiet "$BEFORE_SHA" "$AFTER_SHA" -- 'commerce-apps-manifest/translations/**'; then
+            translations_changed=true
+          fi
+          # Non-CAP: every tracked file except ZIPs, their sibling
+          # catalog.json, extracted icons, manifest.json, and translations
+          # (each of those is promoted separately above/below via its own
+          # merge, not a plain patch). One patch file PER changed path (not one
+          # combined patch): git apply/reverse-check are all-or-nothing, so a
+          # single conflicting or binary file must not drop every other,
+          # unrelated file bundled into the same push.
+          stash="$RUNNER_TEMP/promote"
+          rm -rf "$stash"; mkdir -p "$stash/non-cap-patches"
+          non_cap_changed=false
+          mapfile -t non_cap_files < <(git diff --name-only "$BEFORE_SHA" "$AFTER_SHA" -- "${NON_CAP_PATHSPEC[@]}")
+          if [[ ${#non_cap_files[@]} -gt 0 ]]; then
+            non_cap_changed=true
+            : > "$stash/non-cap-files.txt"
+            for f in "${non_cap_files[@]}"; do
+              printf '%s\n' "$f" >> "$stash/non-cap-files.txt"
+              slug="$(echo "$f" | tr '/' '_')"
+              git diff --binary "$BEFORE_SHA" "$AFTER_SHA" -- "$f" > "$stash/non-cap-patches/$slug.patch"
+            done
+          fi
+
+          if [[ ${#changed_zips[@]} -eq 0 && "$manifest_changed" == "false" && "$translations_changed" == "false" && "$non_cap_changed" == "false" ]]; then
+            echo "No promotable changes (no ZIPs, manifest, translations, or non-CAP files). Nothing to promote."
             echo "promote=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+
+          # validate_manifest only after confirming there's something to
+          # promote: an unrelated push (docs/skills-only) with no ZIP/manifest/
+          # translations change must not be hard-failed by a pre-existing
+          # manifest defect it never touches, now that this workflow fires on
+          # every push rather than only ZIP-touching ones.
+          validate_manifest "$manifest_path"
 
           # 2) Determine the next hop from the live remote branch list. Fail loud
           #    if the remote returned nothing: an empty list would make
@@ -266,11 +310,12 @@ jobs:
           fi
           echo "Promoting $SOURCE_REF -> $next"
 
-          # 3) Stash source artifacts (ZIP bytes + source manifest) BEFORE we
-          #    switch to the target working tree.
-          stash="$RUNNER_TEMP/promote"
-          rm -rf "$stash"; mkdir -p "$stash"
+          # 3) Stash remaining source artifacts (ZIP bytes + source manifest)
+          #    into the SAME stash dir from step 1 (which already holds the
+          #    per-file non-cap patches) BEFORE we switch to the target
+          #    working tree.
           cp "$manifest_path" "$stash/source-manifest.json"
+          [[ -d commerce-apps-manifest/translations ]] && cp -r commerce-apps-manifest/translations "$stash/source-translations"
           : > "$stash/items.tsv"
 
           for zip_path in "${changed_zips[@]}"; do
@@ -303,8 +348,8 @@ jobs:
             printf '%s\t%s\t%s\n' "$zip_path" "$version" "$category" >> "$stash/items.tsv"
           done
 
-          if [[ ! -s "$stash/items.tsv" ]]; then
-            echo "No promotable ZIPs (all deletions). Nothing to promote."
+          if [[ ! -s "$stash/items.tsv" && "$manifest_changed" == "false" && "$translations_changed" == "false" && "$non_cap_changed" == "false" ]]; then
+            echo "No promotable ZIPs (all deletions) and no manifest/translations/non-CAP changes. Nothing to promote."
             echo "promote=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -372,6 +417,58 @@ jobs:
             fi
           done < "$stash/items.tsv"
 
+          # 5e) Manifest entries not tied to a specific promoted ZIP (e.g. a
+          #     manual, hand-edited manifest.json change pushed with no ZIP)
+          #     still need to reach the target. Merge the whole source
+          #     manifest in - the same monotonic, id-keyed guard as 5b makes
+          #     this idempotent alongside the per-ZIP merges above (any entry
+          #     already merged in 5b is a byte-identical no-op here).
+          if [[ "$manifest_changed" == "true" ]]; then
+            tmp="$(mktemp)"
+            merge_manifest_file "$manifest_path" "$stash/source-manifest.json" > "$tmp"
+            mv "$tmp" "$manifest_path"
+            git add "$manifest_path"
+          fi
+
+          # 5f) Translations locale files (commerce-apps-manifest/translations/*.json)
+          #     merge additively per key (app id) - never overwriting a key the
+          #     target already has, so two branches independently adding
+          #     different apps' translations to the same locale file never
+          #     conflict, unlike a textual patch on the same file.
+          if [[ "$translations_changed" == "true" ]]; then
+            for locale_path in "$stash/source-translations"/*.json; do
+              [[ -f "$locale_path" ]] || continue
+              locale_file="$(basename "$locale_path")"
+              target_locale="commerce-apps-manifest/translations/$locale_file"
+              [[ -f "$target_locale" ]] || echo '{}' > "$target_locale"
+              tmp="$(mktemp)"
+              merge_translations_file "$target_locale" "$locale_path" > "$tmp"
+              mv "$tmp" "$target_locale"
+              git add "$target_locale"
+            done
+          fi
+
+          # 5g) Non-CAP file changes (docs, skills, and other plain-content
+          #     files - excludes .github/workflows/**, see NON_CAP_PATHSPEC)
+          #     - not a monotonic merge, so apply
+          #     via a per-file patch that no-ops if already present on the
+          #     target and is skipped (never forced) on genuine conflict with
+          #     intentional per-branch divergence. Per-file (not one combined
+          #     patch) so one conflicting/binary file never drops the rest.
+          #     apply_non_cap_patch already stages the result via
+          #     `git apply --index` (including deletions) - no extra `git add`
+          #     needed, and `git add` on a deleted path would fail under `set -e`.
+          if [[ "$non_cap_changed" == "true" ]]; then
+            while IFS= read -r f; do
+              [[ -z "$f" ]] && continue
+              slug="$(echo "$f" | tr '/' '_')"
+              patch_file="$stash/non-cap-patches/$slug.patch"
+              [[ -f "$patch_file" ]] || continue
+              result="$(apply_non_cap_patch "$patch_file")"
+              echo "Non-CAP patch result for $f: $result"
+            done < "$stash/non-cap-files.txt"
+          fi
+
           if git diff --cached --quiet; then
             echo "Target $next already carries these artifacts. Nothing to promote."
             echo "promote=false" >> "$GITHUB_OUTPUT"
@@ -398,14 +495,18 @@ jobs:
           commit-message: "CI: promote app artifacts from ${{ github.ref_name }} to ${{ steps.prepare.outputs.next_branch }}"
           title: "CI: promote from ${{ github.ref_name }} → ${{ steps.prepare.outputs.next_branch }}"
           body: |
-            Forward-integration PR auto-generated after a ZIP merged into `${{ github.ref_name }}`.
+            Forward-integration PR auto-generated after a push to `${{ github.ref_name }}`.
 
-            Carries the promoted artifacts, already merged, into `${{ steps.prepare.outputs.next_branch }}`:
+            Carries the promoted changes, already merged, into `${{ steps.prepare.outputs.next_branch }}`:
 
-            - The app ZIP(s)
-            - The matching `commerce-apps-manifest/manifest.json` entry (monotonic upsert keyed by app id)
+            - Any app ZIP(s)
+            - The matching `commerce-apps-manifest/manifest.json` entry/entries (monotonic upsert keyed by app id)
             - The merged `catalog.json` (union `versions`, monotonic `latest`)
             - Any app icons under `commerce-apps-manifest/icons/`
+            - Any `commerce-apps-manifest/translations/*.json` changes (additive per-key merge, keyed by app id)
+            - Any other non-CAP file changes (docs, skills, etc. - excluding `.github/workflows/**`, which
+              `GITHUB_TOKEN` cannot push), applied as a patch that is skipped rather than forced if it
+              conflicts with intentional per-branch divergence
 
             Merging this PR re-triggers the catalog workflow on `${{ steps.prepare.outputs.next_branch }}`,
             which promotes forward to the next branch in the chain. Tags are immutable and shared,

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -499,6 +499,19 @@ jobs:
               done
             done
 
+            # SFRA is additive-only to SFNext: reject sfra declared without sfnext,
+            # checked on both the manifest entry and the extracted commerce-app.json.
+            if ! validate_sfra_requires_sfnext "$entry" "manifest entry for $zip_file" "$manifest_path"; then
+              rm -rf "$tmpdir"
+              exit 1
+            fi
+            if [[ -n "$commerce_app" && -f "$commerce_app" ]]; then
+              if ! validate_sfra_requires_sfnext "$(cat "$commerce_app")" "commerce-app.json for $zip_file" "$manifest_path"; then
+                rm -rf "$tmpdir"
+                exit 1
+              fi
+            fi
+
             # Cross-validate every storefrontSupport min/max value between manifest and commerce-app.json.
             for storefront in sfnext sfra; do
               for field in minVersion maxVersion; do


### PR DESCRIPTION
## Summary
Forward-ports two commits that landed directly on `main` and never entered the release-branch promotion chain, since `promote-forward` only fires on pushes to `release/**`, not `main`:

- f13776736d236ddd4c75e10ae032fdda249c58f0 — Carry non-CAP file changes forward across release branches (#72)
- c39147bea448dbf1f4a3992431f5b915eaf0b276 — Enforce SFRA-requires-SFNext in verify-zip.yml CI validation (#73)

Landing the first commit here also unblocks future non-CAP (scripts/docs) changes pushed to `release/26.8` from auto-promoting forward to `release/26.9` and `main`.

## Test plan
- [ ] CI passes (existing promotion-utils and root-manifest-utils unit tests)
- [ ] Confirm `validate_sfra_requires_sfnext` is wired into verify-zip.yml step 8 on this branch