### PR TITLE
No SFRA-only apps; require ISV partnership agreement

### DIFF
--- a/.claude/skills/package-app/SKILL.md
+++ b/.claude/skills/package-app/SKILL.md
@@ -28,7 +28,7 @@ Build a registry-ready Commerce App Package (CAP) ZIP from an app directory.
 | Publisher URL | `https://developer.avalara.com/` | Yes |
 | SFNext min version | `1.0.0` | No |
 | SFNext max version | `2.0.0` | No |
-| SFRA min version | `7.0.0` | No |
+| SFRA min version | `7.0.0` | No — only valid if SFNext min version is also set |
 | SFRA max version | `8.0.0` | No |
 
 **Valid domains:** `tax`, `payment`, `shipping`, `gift-cards`, `ratings-and-reviews`, `loyalty`, `search`, `address-verification`, `analytics`, `approaching-discounts`, `fraud`
@@ -76,7 +76,7 @@ Ensure version matches throughout:
 }
 ```
 
-> **Note:** `storefrontSupport` is optional. Include only if the app declares a minimum storefront version. Omit the entire object if no version gating is needed. `maxVersion` is optional within each storefront key — include it only to guard against a known-incompatible future version (e.g., a major release that removes target IDs the app depends on); omit it for "no upper bound." When present, the values here must match the root manifest entry exactly.
+> **Note:** `storefrontSupport` is optional. Include only if the app declares a minimum storefront version. Omit the entire object if no version gating is needed. `maxVersion` is optional within each storefront key — include it only to guard against a known-incompatible future version (e.g., a major release that removes target IDs the app depends on); omit it for "no upper bound." An `sfra` key without an `sfnext` key will fail validation — SFRA support is always additive to SFNext. When present, the values here must match the root manifest entry exactly.
 
 ## Step 4: Run validation
 
@@ -141,7 +141,7 @@ Update `commerce-apps-manifest/manifest.json`:
 }
 ```
 
-> **Note:** Include `storefrontSupport` only if the app declares a minimum storefront version. Omit the entire field if no version gating is needed. `maxVersion` is optional within each storefront key — include it only to guard against a known-incompatible future version; omit it for "no upper bound." Values must match the corresponding fields in `commerce-app.json` exactly.
+> **Note:** Include `storefrontSupport` only if the app declares a minimum storefront version. Omit the entire field if no version gating is needed. `maxVersion` is optional within each storefront key — include it only to guard against a known-incompatible future version; omit it for "no upper bound." An `sfra` key without an `sfnext` key will fail validation — SFRA support is always additive to SFNext. Values must match the corresponding fields in `commerce-app.json` exactly.
 
 **Icon:** Must match filename in ZIP's `icons/` directory. CI extracts automatically.
 

--- a/.claude/skills/scaffold-app/SKILL.md
+++ b/.claude/skills/scaffold-app/SKILL.md
@@ -56,10 +56,10 @@ If the user's description clearly indicates type, proceed directly. Otherwise as
 - Publisher name and URL
 - Minimum SFNext version (optional - semver `X.Y.Z` or `X.Y.Z-prerelease`, if the app requires a minimum Storefront Next version)
 - Maximum SFNext version (optional - semver, inclusive; only set if you've confirmed an incompatibility — e.g., a known-breaking future major release)
-- Minimum SFRA version (optional - semver `X.Y.Z` or `X.Y.Z-prerelease`, if the app requires a minimum SFRA version)
-- Maximum SFRA version (optional - semver, inclusive; same guidance as above)
+- Minimum SFRA version (optional - semver `X.Y.Z` or `X.Y.Z-prerelease`, if the app requires a minimum SFRA version) — **only ask this if a minimum SFNext version was provided above.** SFRA is additive to SFNext and may never be declared alone; don't offer an SFRA-only path.
+- Maximum SFRA version (optional - semver, inclusive; same guidance as above; only applicable if SFRA min version was set)
 
-> When provided, add `storefrontSupport` to both `commerce-app.json` (inside the ZIP) and the root manifest entry. Values must match. Each storefront key (`sfnext`, `sfra`) accepts `minVersion` (required when the key is present) and an optional `maxVersion`.
+> When provided, add `storefrontSupport` to both `commerce-app.json` (inside the ZIP) and the root manifest entry. Values must match. Each storefront key (`sfnext`, `sfra`) accepts `minVersion` (required when the key is present) and an optional `maxVersion`. `sfra` requires `sfnext` to also be present — never generate a `storefrontSupport` object with `sfra` but no `sfnext`.
 - Additional context (optional - docs, requirements, API details)
 
 **Folder Structure:** Apps must be at `{domain}/{appName}/` where `{appName}` matches the "id" field. Installation URL: `https://raw.githubusercontent.com/{owner}/{repo}/{tag}/{domain}/{appName}/{zipFileName}`

--- a/.claude/skills/validate-app/SKILL.md
+++ b/.claude/skills/validate-app/SKILL.md
@@ -87,6 +87,7 @@ Optional fields (validate if present):
 - `storefrontSupport.sfra.minVersion` - valid semver (`X.Y.Z` or `X.Y.Z-prerelease`)
 - `storefrontSupport.sfra.maxVersion` - valid semver, optional (`X.Y.Z` or `X.Y.Z-prerelease`)
 - Only `sfnext` and `sfra` keys allowed inside `storefrontSupport`; only `minVersion` and `maxVersion` allowed inside each
+- If `storefrontSupport.sfra` is present, `storefrontSupport.sfnext` must also be present (with a valid `minVersion`). Fail validation on SFRA-only declarations.
 - `storefrontSupport` must be present in **both** the root manifest and `commerce-app.json` with matching values
 
 ## Step 5: Validate package contents
@@ -142,6 +143,7 @@ Optional fields (validate if present):
 - `storefrontSupport.sfnext.maxVersion` - valid semver, optional (`X.Y.Z` or `X.Y.Z-prerelease`)
 - `storefrontSupport.sfra.minVersion` - valid semver (`X.Y.Z` or `X.Y.Z-prerelease`)
 - `storefrontSupport.sfra.maxVersion` - valid semver, optional (`X.Y.Z` or `X.Y.Z-prerelease`)
+- If `storefrontSupport.sfra` is present, `storefrontSupport.sfnext` must also be present (with a valid `minVersion`). Fail validation on SFRA-only declarations.
 - Values must match the corresponding fields in the root manifest entry
 
 ## Step 8: Validate storefront files (UI-only/Fullstack)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,6 +36,7 @@
 - [ ] `catalog.json` included for new apps only (with INIT values)
 - [ ] If updating existing app: Did NOT add new versions to `catalog.json` (CI handles this)
 - [ ] If deprecating a version: Added `"deprecated": true` to existing version in `catalog.json`
+- [ ] If the app declares SFRA support, it also declares SFNext support (no SFRA-only apps)
 
 ### Version and Hash Validation
 - [ ] `version` in `manifest.json` matches `version` in `commerce-app.json`
@@ -101,3 +102,4 @@
 - I am only committing ZIP, manifest.json, translations, and catalog.json (no extracted directories)
 - All hardcoded credentials are placeholders, not production values
 - I have signed the Contributor License Agreement (CLA) if I am an external contributor
+- This app is covered by an appropriate ISV partnership agreement with Salesforce

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,12 +184,12 @@ Your response:
 ### 8. Storefront Support (Optional)
 - `storefrontSupport` must be present in **both** the root manifest entry and `commerce-app.json` inside the ZIP
 - Use semver format (`X.Y.Z` or `X.Y.Z-prerelease`) for all `minVersion` and `maxVersion` fields
-- Apps may declare `sfnext`, `sfra`, or both
+- Apps may declare `sfnext` alone, or `sfnext` + `sfra`. Declaring `sfra` without `sfnext` is invalid.
 - `minVersion` is required when the storefront key is present; `maxVersion` is optional and inclusive
 - Use `maxVersion` only to guard against a known-incompatible future version (e.g., a major release that removes target IDs the app depends on); absence means "no upper bound"
 - If absent, no version gating is applied at install time
 - Values must match exactly between root manifest and `commerce-app.json`
-- Only `sfnext` and `sfra` keys are allowed inside `storefrontSupport`; only `minVersion` and `maxVersion` are allowed inside each storefront object
+- Only `sfnext` and `sfra` keys are allowed inside `storefrontSupport`; only `minVersion` and `maxVersion` are allowed inside each storefront object, and `sfra` requires `sfnext` to also be present.
 
 **Icon validation examples:**
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,10 @@ These skills automate many of the manual steps described below and help catch co
 
 ---
 
+## ISV Partnership Requirement
+
+Every published app must be covered by an appropriate ISV partnership agreement with Salesforce. This applies regardless of app architecture (UI-only, backend-only, or fullstack) or domain. PRs from ISVs without a current, applicable partnership agreement will not be merged. If you're unsure whether your agreement covers the app you're submitting, contact your partner account manager or file a support case in the partner portal before opening a PR.
+
 ## Pull Request Requirements
 
 Each PR **must** include the following items:
@@ -151,8 +155,9 @@ Find your app’s entry in the appropriate domain array (e.g., `tax`, `shipping`
   - `sfra` - (Object) SFRA compatibility
     - `minVersion` - (String) Minimum SFRA version the app requires (semver format: `X.Y.Z` or `X.Y.Z-prerelease`)
     - `maxVersion` - (String, optional) Maximum SFRA version the app supports, inclusive (semver format: `X.Y.Z` or `X.Y.Z-prerelease`).
+    - `sfra` may only be declared alongside `sfnext`. An app may not declare `sfra` support without also declaring `sfnext` support.
 
-An app may declare support for one or both storefront types. If the `storefrontSupport` field is absent or a specific storefront key is omitted, no version gating is applied for that storefront. Omit `maxVersion` unless you have confirmed an incompatibility — the installer treats absence as "no upper bound."
+An app may declare `sfnext` alone, or `sfnext` and `sfra` together. An app may **not** declare `sfra` alone — SFRA support is always additive to SFNext. If `storefrontSupport` is absent (e.g., a backend-only app), no version gating is applied. Omit `maxVersion` unless you have confirmed an incompatibility — the installer treats absence as "no upper bound."
 
 When present, the `storefrontSupport` field in the root manifest must match the `storefrontSupport` field in the app's `commerce-app.json` inside the ZIP.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Merchants install Commerce Apps through Business Manager with a click-to-install
 | **API Adapter Only** | Script API hooks implementing platform contracts | Hook dispatch, lifecycle management | Tax calculation (Avalara), fraud detection |
 | **Full App** | Both UI components and backend adapters | All of the above | Shipping estimator, BNPL provider |
 
+Apps that target a storefront must declare Storefront Next (SFNext) support; SFRA support is additive and may only be declared alongside SFNext — SFRA-only apps aren't accepted.
+
 ## Quick Start
 
 ### Using Agent Skills
@@ -484,6 +486,8 @@ The repository `.gitignore` is configured to exclude extracted directories and s
 ### External Contributors
 
 All external contributors must sign the Contributor License Agreement (CLA). A prompt to sign the agreement appears when a pull request is submitted.
+
+Beyond the CLA, every published app must be covered by an appropriate ISV partnership agreement with Salesforce. This is a business/legal requirement independent of code review — contact your partner account manager if you're unsure whether your agreement covers the app you're submitting.
 
 ## Disclaimer
 


### PR DESCRIPTION
## Summary
- SFRA support may no longer be declared without also declaring SFNext support — closes the gap where SFRA-only apps were implicitly allowed. Enforcement added to `validate-app` SKILL.md; `scaffold-app` and `package-app` updated to guide contributors accordingly; `CONTRIBUTING.md`, `AGENTS.md`, `README.md`, and the PR template updated for visibility.
- Documents that every published app must be covered by an appropriate ISV partnership agreement with Salesforce (`CONTRIBUTING.md`, `README.md`, PR template).

## Test plan
- [x] Docs-only change; no code paths affected