### PR TITLE
W-23695735: Anchor icon extraction to CAP root, seed catalog.json as INIT on new-app promotion

### DIFF
--- a/.github/scripts/promotion-utils.sh
+++ b/.github/scripts/promotion-utils.sh
@@ -55,6 +55,25 @@ next_release_branch() {
   fi
 }
 
+# Prints the path to a CAP's own icons/ directory within its unpacked ZIP, or
+# nothing if it has none.
+#
+#   find_cap_icons_dir <extracted_zip_root>
+#
+# ZIPs unpack to <extracted_zip_root>/<cap-root>/, so the CAP-level icons/ is
+# always exactly two levels below the extraction root (one level below the
+# cap-root). Anchoring to that exact depth (rather than an unbounded
+# `find -name icons`) avoids picking up an
+# unrelated nested icons/ dir that a bundled cartridge asset may carry (e.g.
+# Business Manager static theme icons under
+# cartridges/*/cartridge/static/default/icons/), which would otherwise be
+# copied into commerce-apps-manifest/icons/ and could overwrite the real app
+# icon with the wrong file.
+find_cap_icons_dir() {
+  local extracted_root="${1:?extracted ZIP root is required}"
+  find "$extracted_root" -mindepth 2 -maxdepth 2 -type d -name icons -print -quit
+}
+
 # Merges a promoted (version, tag) into the target branch's catalog.json and
 # prints the merged JSON to stdout. Two invariants:
 #   - versions is a union: the (version, tag) pair is appended only when absent,

--- a/.github/scripts/test-promotion-utils.sh
+++ b/.github/scripts/test-promotion-utils.sh
@@ -69,6 +69,10 @@ mkfile() {
   printf '%s' "$f"
 }
 
+mkextractdir() {
+  mktemp -d "$TMPDIR_ROOT/extract_XXXXXX"
+}
+
 BRANCHES="$(printf '%s\n' \
   refs/heads/main \
   refs/heads/release/26.8 \
@@ -78,6 +82,41 @@ BRANCHES="$(printf '%s\n' \
   refs/heads/CI/update-catalog-123)"
 
 echo "=== promotion-utils.sh tests ==="
+echo ""
+
+# ---------------------------------------------------------------------------
+# find_cap_icons_dir
+# ---------------------------------------------------------------------------
+echo "--- find_cap_icons_dir ---"
+
+# CAP root icons/ is found (the normal case: <root>/<cap>/icons/).
+e1="$(mkextractdir)"
+mkdir -p "$e1/commerce-avalara-tax-app-v1.1.3/icons"
+touch "$e1/commerce-avalara-tax-app-v1.1.3/icons/avalara.png"
+assert_eq "finds CAP-root icons dir" \
+  "$e1/commerce-avalara-tax-app-v1.1.3/icons" \
+  find_cap_icons_dir "$e1"
+
+# A nested icons/ dir inside a cartridge (e.g. BM static theme assets) must be
+# ignored; only the CAP-root one is returned. This is the exact shape of the
+# bug from PR #87: a nested icons/ dir was picked up instead of the CAP root.
+e2="$(mkextractdir)"
+mkdir -p "$e2/commerce-avalara-tax-app-v1.1.3/icons"
+touch "$e2/commerce-avalara-tax-app-v1.1.3/icons/avalara.png"
+mkdir -p "$e2/commerce-avalara-tax-app-v1.1.3/cartridges/int_avatax/cartridge/static/default/icons"
+touch "$e2/commerce-avalara-tax-app-v1.1.3/cartridges/int_avatax/cartridge/static/default/icons/circle-info-solid-min.png"
+assert_eq "ignores nested cartridge-static icons dir" \
+  "$e2/commerce-avalara-tax-app-v1.1.3/icons" \
+  find_cap_icons_dir "$e2"
+
+# No CAP-root icons/ dir at all -> prints nothing, even if a nested one exists.
+e3="$(mkextractdir)"
+mkdir -p "$e3/commerce-noicon-app-v1.0.0/cartridges/int_noicon/cartridge/static/default/icons"
+touch "$e3/commerce-noicon-app-v1.0.0/cartridges/int_noicon/cartridge/static/default/icons/theme.png"
+assert_eq "no CAP-root icons dir -> empty" \
+  "" \
+  find_cap_icons_dir "$e3"
+
 echo ""
 
 # ---------------------------------------------------------------------------

--- a/.github/workflows/update-catalog.yml
+++ b/.github/workflows/update-catalog.yml
@@ -132,8 +132,9 @@ jobs:
               tmpdir="$(mktemp -d)"
               unzip -q "$zip_path" -d "$tmpdir"
 
-              # Find icons directory in the extracted CAP
-              icons_dir="$(find "$tmpdir" -type d -name icons -print -quit)"
+              # Anchored to the CAP root - see find_cap_icons_dir in
+              # promotion-utils.sh for why this must not be an unbounded find.
+              icons_dir="$(find_cap_icons_dir "$tmpdir")"
 
               if [[ -n "$icons_dir" && -d "$icons_dir" ]]; then
                 echo "Extracting icons from $zip_path for ISV: $isv_name"
@@ -163,6 +164,8 @@ jobs:
                     fi
                   fi
                 done
+              else
+                echo "No top-level icons directory found in $zip_path for ISV: $isv_name; skipping icon extraction."
               fi
 
               rm -rf "$tmpdir"
@@ -389,12 +392,20 @@ jobs:
             git add "$manifest_path"
 
             # 5c) catalog.json next to the ZIP (union versions, monotonic latest).
-            #     Seed an empty catalog for a brand-new app on the target.
+            #     A brand-new app on the target has no catalog.json yet - seed
+            #     it with the INIT template and skip merge_catalog_json so the
+            #     target branch's own post-merge update-catalog run is what
+            #     first populates version history (the CONTRIBUTING.md
+            #     contract for new apps), instead of the promotion writing a
+            #     concrete version here and duplicating that work.
             catalog_path="$(dirname "$zip_path")/catalog.json"
-            [[ -f "$catalog_path" ]] || echo '{}' > "$catalog_path"
-            tmp="$(mktemp)"
-            merge_catalog_json "$catalog_path" "$version" "$tag_name" > "$tmp"
-            mv "$tmp" "$catalog_path"
+            if [[ -f "$catalog_path" ]]; then
+              tmp="$(mktemp)"
+              merge_catalog_json "$catalog_path" "$version" "$tag_name" > "$tmp"
+              mv "$tmp" "$catalog_path"
+            else
+              printf '{\n  "latest": {\n    "version": "INIT",\n    "tag": "INIT"\n  },\n  "versions": []\n}\n' > "$catalog_path"
+            fi
             git add "$catalog_path"
 
             # 5d) Icons: copy from the ZIP into the shared icons dir.
@@ -402,7 +413,9 @@ jobs:
             if [[ -n "$isv_name" ]]; then
               tmpdir="$(mktemp -d)"
               unzip -q "$zip_path" -d "$tmpdir"
-              icons_dir="$(find "$tmpdir" -type d -name icons -print -quit)"
+              # Anchored to the CAP root - see find_cap_icons_dir in
+              # promotion-utils.sh for why this must not be an unbounded find.
+              icons_dir="$(find_cap_icons_dir "$tmpdir")"
               if [[ -n "$icons_dir" && -d "$icons_dir" ]]; then
                 mapfile -t icon_files < <(find "$icons_dir" -type f \( -iname "*.png" -o -iname "*.svg" -o -iname "*.jpg" -o -iname "*.jpeg" \) -print)
                 for icon_file in "${icon_files[@]}"; do
@@ -412,6 +425,8 @@ jobs:
                     git add "$dest_icon"
                   fi
                 done
+              else
+                echo "No top-level icons directory found in $zip_path for ISV: $isv_name; skipping icon extraction."
               fi
               rm -rf "$tmpdir"
             fi

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -311,6 +311,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          source ".github/scripts/promotion-utils.sh"
 
           [[ -s changed_zips.txt ]] || exit 0
 
@@ -331,11 +332,12 @@ jobs:
 
             unzip -q "$zip_path" -d "$tmpdir"
 
-            # Find icons directory in the extracted CAP
-            icons_dir="$(find "$tmpdir" -type d -name icons -print -quit)"
+            # Anchored to the CAP root - see find_cap_icons_dir in
+            # promotion-utils.sh for why this must not be an unbounded find.
+            icons_dir="$(find_cap_icons_dir "$tmpdir")"
 
             if [[ -z "$icons_dir" || ! -d "$icons_dir" ]]; then
-              echo "No icons directory found in $zip_path - skipping icon validation"
+              echo "No top-level icons directory found in $zip_path - skipping icon validation"
               rm -rf "$tmpdir"
               trap - RETURN
               continue


### PR DESCRIPTION
## Summary

Fixes two bugs in the catalog/promotion CI (per W-23695735, surfaced by PR #90's promote-forward run on the Avalara app):

1. **Unbounded icon extraction.** `find "$tmpdir" -type d -name icons -print -quit` could match a nested `icons/` dir inside a bundled cartridge (e.g. Business Manager static theme assets under `cartridges/*/cartridge/static/default/icons/`) instead of the CAP's own root-level `icons/`. This is exactly what happened on PR #87: `commerce-apps-manifest/icons/avalara.png` was overwritten by a cartridge-static PNG. Fixed by extracting a pure, unit-tested `find_cap_icons_dir()` helper into `promotion-utils.sh`, anchored two levels below the extraction root (`-mindepth 2 -maxdepth 2`), and using it in all three call sites: `update-catalog-pr`, `promote-forward`, and `verify-zip.yml`'s icon-uniqueness check.
2. **catalog.json seeded with a concrete version during promotion.** When `promote-forward` carried a brand-new app onto a target branch with no existing `catalog.json`, it seeded `{}` and then ran `merge_catalog_json`, writing a real version into the target branch — duplicating what the target's own post-merge `update-catalog-pr` job does, and violating the CONTRIBUTING.md contract that new apps land with the `INIT` template. Fixed: if `catalog_path` doesn't exist, write the INIT template directly and skip the merge; existing apps are unaffected.

## Changes

- `.github/scripts/promotion-utils.sh`: new `find_cap_icons_dir()` helper (pure, testable).
- `.github/scripts/test-promotion-utils.sh`: 3 new tests — CAP-root icons found, nested cartridge-static icons dir correctly ignored (regression test for the exact PR #87 shape), and the no-icons-dir case.
- `.github/workflows/update-catalog.yml`: both icon-extraction call sites (`update-catalog-pr`, `promote-forward`) now call `find_cap_icons_dir`; log (don't fail) when no icons dir is found; `promote-forward`'s catalog.json handling now seeds INIT for brand-new apps instead of merging a concrete version.
- `.github/workflows/verify-zip.yml`: Step 6 icon-uniqueness check had the same unbounded-find bug — sources `promotion-utils.sh` and uses the same helper.

## Test plan

- [x] `bash .github/scripts/run-all-tests.sh` — all 6 suites, 24/24 promotion-utils assertions pass.
- [x] `actionlint` on both modified workflow files — clean.
- [x] `shellcheck` on modified scripts — clean (no new findings).
- [x] Manually simulated `find_cap_icons_dir` against the real `tax/avalara-tax/avalara-tax-v1.1.3.zip` — resolves to exactly `avalara.png` (7891 bytes), matching the current manifest icon.
- [x] Manually reproduced the PR #87 bug shape (CAP-root `icons/` + nested cartridge-static `icons/` in the same ZIP) — confirms only the CAP-root icon is now selected.