### PR TITLE
@W-23748575: Require .project file in every CAP cartridge

### DIFF
--- a/.claude/skills/package-app/SKILL.md
+++ b/.claude/skills/package-app/SKILL.md
@@ -95,12 +95,30 @@ cd <domain>/<appName>/
 rm -f <appName>-v*.zip
 ```
 
-## Step 6: Generate ZIP
+## Step 6: Ensure cartridge `.project` files, then generate ZIP
+
+**Backend/Fullstack apps only:** Before zipping, every immediate child directory under `cartridges/site_cartridges/` and `cartridges/bm_cartridges/` MUST have a `.project` file — required for b2c cartridge discovery. If missing, create an empty one. **Never overwrite an existing (possibly non-empty, Eclipse-generated) `.project` file.**
+
+```bash
+cd commerce-<appName>-app-v<version>/
+for group in site_cartridges bm_cartridges; do
+  dir="cartridges/$group"
+  [[ -d "$dir" ]] || continue
+  for cartridge in "$dir"/*/; do
+    [[ -e "$cartridge/.project" ]] || touch "$cartridge/.project"
+  done
+done
+cd ..
+```
+
+Generate the ZIP. **Do NOT use a blanket `-x "*/.*"` exclusion** — it strips the `.project` files just created. Exclude junk explicitly instead:
 
 ```bash
 cd <domain>/<appName>/
 zip -r <appName>-v<version>.zip commerce-<appName>-app-v<version>/ \
-  -x "*.DS_Store" -x "__MACOSX/*" -x "*/.*" -x "Thumbs.db"
+  -x "*.DS_Store" -x "*/*.DS_Store" -x "__MACOSX/*" -x "*/__MACOSX/*" \
+  -x "*/.git/*" -x "*/.env" -x "*/.env.*" -x "Thumbs.db" \
+  -x "*.key" -x "*.pem" -x "*.p12" -x "*.pfx" -x "*.jks"
 ```
 
 Verify structure:
@@ -110,7 +128,8 @@ unzip -l <appName>-v<version>.zip | head -20
 
 Confirm:
 - Single root: `commerce-<appName>-app-v<version>/`
-- No junk files
+- No junk files (`.DS_Store`, `__MACOSX`, `.env`, secrets)
+- **`.project` files ARE present** for every cartridge root (Backend/Fullstack apps) — verify with `unzip -l <appName>-v<version>.zip | grep '\.project$'`
 - Architecture-specific directories present
 
 ## Step 7: Compute hash

--- a/.claude/skills/package-app/evals/evals.json
+++ b/.claude/skills/package-app/evals/evals.json
@@ -22,7 +22,7 @@
     {
       "id": 4,
       "prompt": "Package my shipping app at shipping/fedex-shipping/commerce-fedex-shipping-app-v2.0.0/. It's a backend-only app with cartridges and impex but no storefront-next. Version 2.0.0, FedEx Corp publisher, icon is fedex-logo.svg. Also this version hasn't been published yet - catalog.json shows 'INIT' for the latest.",
-      "expected_output": "Detects backend-only architecture (has cartridges/ and impex/, no storefront-next/). Since catalog.json shows INIT and version not in versions array, asks user if they want to: (1) replace v2.0.0 with changes, or (2) bump to new version for tracking. Waits for user choice. After choice, runs security scan, generates ZIP, updates manifest with iconName='fedex-logo.svg', adds translations, validates backend-specific requirements (impex/, cartridges/, hooks.json), cleans up extracted directory.",
+      "expected_output": "Detects backend-only architecture (has cartridges/ and impex/, no storefront-next/). Since catalog.json shows INIT and version not in versions array, asks user if they want to: (1) replace v2.0.0 with changes, or (2) bump to new version for tracking. Waits for user choice. After choice, ensures every cartridge root has a .project file (creating an empty one if missing, without overwriting an existing one), runs security scan, generates ZIP without the blanket '-x \"*/.*\"' exclusion (so .project is preserved), updates manifest with iconName='fedex-logo.svg', adds translations, validates backend-specific requirements (impex/, cartridges/, hooks.json), cleans up extracted directory.",
       "files": []
     },
     {
@@ -40,7 +40,7 @@
     {
       "id": 7,
       "prompt": "I have this fullstack gift card app at gift-cards/giftcards-com/commerce-giftcards-com-app-v1.1.0/ that needs packaging. It has both storefront-next UI components AND backend cartridges with impex. The icon is at icons/giftcards-logo.png and that should go in the manifest as iconName. Publisher is Giftcards.com Inc.",
-      "expected_output": "Detects fullstack architecture (has BOTH storefront-next/ AND cartridges/ with impex/). Runs security scan. Creates ZIP validating BOTH UI requirements (target-config.json, locales, TypeScript structure) AND backend requirements (cartridges/site_cartridges/, package.json with hooks field, impex/install/, impex/uninstall/). Updates manifest with iconName='giftcards-logo.png', adds translations, validates folder structure matches gift-cards/giftcards-com/ pattern... WAIT - should be gift-cards/{appName}/ not gift-cards/giftcards-com/. Catches folder structure issue.",
+      "expected_output": "Detects fullstack architecture (has BOTH storefront-next/ AND cartridges/ with impex/). Ensures every cartridge root under cartridges/site_cartridges/ and cartridges/bm_cartridges/ has a .project file before zipping. Runs security scan. Creates ZIP without the blanket '-x \"*/.*\"' exclusion (so .project files are preserved), validating BOTH UI requirements (target-config.json, locales, TypeScript structure) AND backend requirements (cartridges/site_cartridges/, package.json with hooks field, impex/install/, impex/uninstall/, .project in every cartridge root). Updates manifest with iconName='giftcards-logo.png', adds translations, validates folder structure matches gift-cards/giftcards-com/ pattern... WAIT - should be gift-cards/{appName}/ not gift-cards/giftcards-com/. Catches folder structure issue.",
       "files": []
     },
     {

--- a/.claude/skills/scaffold-app/SKILL.md
+++ b/.claude/skills/scaffold-app/SKILL.md
@@ -105,7 +105,13 @@ mkdir -p impex/{install/meta,install/sites/SITEID,uninstall}
 
 # Fullstack only: Add Business Manager cartridge
 mkdir -p cartridges/bm_cartridges/bm_<appName>
+
+# Every cartridge root needs an empty .project file (required for b2c cartridge discovery)
+touch cartridges/site_cartridges/<cartridgeName>/.project
+touch cartridges/bm_cartridges/bm_<appName>/.project
 ```
+
+**`.project` files:** Every cartridge root (each immediate child of `cartridges/site_cartridges/` and `cartridges/bm_cartridges/`) MUST contain a `.project` file — required for b2c cartridge discovery. `create_structure.sh` creates these empty automatically. If a developer later imports a real Eclipse-generated `.project` file (non-empty), leave it as-is — don't overwrite it.
 
 This structure enables the installation URL pattern and allows side-by-side development of different versions.
 
@@ -205,6 +211,7 @@ Check:
 - [ ] **app-configuration/tasksList.json created** with merchant post-installation tasks
 - [ ] Backend apps: cartridge files, hooks.json (with explicit script paths), **both install/ and uninstall/ impex directories**
 - [ ] Backend apps: package.json includes `"hooks": "cartridge/scripts/hooks.json"` field
+- [ ] Backend/Fullstack apps: every cartridge root (`cartridges/site_cartridges/<cartridgeName>/`, `cartridges/bm_cartridges/bm_<appName>/`) has a `.project` file (empty is fine)
 - [ ] Backend apps: Hook implementations use `require()` not `importPackage()`, always return dw.system.Status
 - [ ] UI apps: storefront-next structure with target-config.json, TypeScript components, tests
 - [ ] UI apps: index.ts barrel file, **all three locale files** (en-US, en-GB, it-IT), i18n usage with useTranslation

--- a/.claude/skills/scaffold-app/evals/evals.json
+++ b/.claude/skills/scaffold-app/evals/evals.json
@@ -144,6 +144,10 @@
         {
           "name": "commerce-app.json exists with correct metadata",
           "description": "All apps need manifest"
+        },
+        {
+          "name": "cartridge roots have .project files",
+          "description": "cartridges/site_cartridges/<cartridgeName>/.project and cartridges/bm_cartridges/bm_<appName>/.project must exist (empty is fine)"
         }
       ]
     },
@@ -209,6 +213,10 @@
         {
           "name": "hooks.json for loyalty domain",
           "description": "Should include loyalty-specific hooks"
+        },
+        {
+          "name": "cartridge roots have .project files",
+          "description": "cartridges/site_cartridges/<cartridgeName>/.project and cartridges/bm_cartridges/bm_<appName>/.project must exist (empty is fine)"
         },
         {
           "name": "all three locale files exist (en-US, en-GB, it-IT)",

--- a/.claude/skills/scaffold-app/scripts/create_structure.sh
+++ b/.claude/skills/scaffold-app/scripts/create_structure.sh
@@ -24,6 +24,12 @@ mkdir -p "cartridges/site_cartridges/${CARTRIDGE_NAME}/cartridge/scripts/"{hooks
 mkdir -p "cartridges/site_cartridges/${CARTRIDGE_NAME}/test/"{mocks,unit}
 mkdir -p "cartridges/bm_cartridges/bm_${APP_NAME}"
 
+# Every cartridge root needs a .project file for b2c cartridge discovery.
+# Empty is fine here — Eclipse-generated .project files are left untouched
+# elsewhere (e.g. when importing an existing cartridge).
+touch "cartridges/site_cartridges/${CARTRIDGE_NAME}/.project"
+touch "cartridges/bm_cartridges/bm_${APP_NAME}/.project"
+
 # Storefront Next extensions
 mkdir -p "storefront-next/src/extensions/${APP_NAME}/"{components,context,hooks,locales,middlewares,providers,routes,stores,tests}
 

--- a/.claude/skills/validate-app/SKILL.md
+++ b/.claude/skills/validate-app/SKILL.md
@@ -110,7 +110,7 @@ done
 
 Check:
 - Single root: `commerce-<appName>-app-v<version>/` (ZIP only — for `INPUT_KIND=dir`, the directory IS the root)
-- No junk files (`.DS_Store`, `__MACOSX`, hidden files)
+- No junk hidden files (`.DS_Store`, `__MACOSX`, `.env`, secrets) — **except** `.project`, which every cartridge root MUST include (see Step 6b)
 - No registry paths (`tax/`, `domain/`) at the ZIP root (ZIP only)
 - Required: `commerce-app.json`, `README.md`, `app-configuration/tasksList.json`
 
@@ -125,6 +125,16 @@ Determine:
 - **UI-only:** Has `storefront-next/`, NO `cartridges/`
 - **Backend-only:** Has `cartridges/`, NO `storefront-next/`
 - **Fullstack:** Has both
+
+## Step 6b: Validate cartridge `.project` files (Backend-only/Fullstack)
+
+**Skip if UI-only** (`HAS_BACKEND=0`).
+
+Every immediate child directory of `cartridges/site_cartridges/` and `cartridges/bm_cartridges/` must contain a `.project` file. It may be empty (auto-created by scaffolding/packaging) or a real, non-empty Eclipse `.project` file — both PASS. Missing is a FAIL.
+
+```bash
+bash .github/scripts/validate-cartridge-project.sh "$CAP_ROOT"
+```
 
 ## Step 7: Validate commerce-app.json
 

--- a/.claude/skills/validate-app/evals/evals.json
+++ b/.claude/skills/validate-app/evals/evals.json
@@ -5,7 +5,7 @@
       "id": 1,
       "prompt": "I just packaged avalara-tax v0.2.8. Can you validate it before I submit the PR?",
       "context": "User has packaged app and wants pre-submission validation",
-      "expected_behavior": "Triggers validate-app skill. Identifies app at tax/avalara-tax/avalara-tax-v0.2.8.zip. Checks: ZIP exists, SHA256 matches manifest, manifest has all required fields, ZIP structure (single root, no junk files), detects architecture (Backend-only/UI-only/Fullstack), validates commerce-app.json version matches manifest, checks architecture-specific requirements, validates impex if Backend/Fullstack, verifies icon filename matches, confirms translations in en-US.json, runs security scan, reports PASS or FAIL with specific issues."
+      "expected_behavior": "Triggers validate-app skill. Identifies app at tax/avalara-tax/avalara-tax-v0.2.8.zip. Checks: ZIP exists, SHA256 matches manifest, manifest has all required fields, ZIP structure (single root, no junk files), detects architecture (Backend-only/UI-only/Fullstack), validates commerce-app.json version matches manifest, checks architecture-specific requirements including every cartridge root having a .project file (empty or non-empty both pass), validates impex if Backend/Fullstack, verifies icon filename matches, confirms translations in en-US.json, runs security scan, reports PASS or FAIL with specific issues."
     },
     {
       "id": 2,
@@ -23,7 +23,7 @@
       "id": 4,
       "prompt": "Validate the fullstack app at loyalty/acme-rewards/acme-rewards-v1.5.0.zip. It has both UI and backend components.",
       "context": "Fullstack app validation request",
-      "expected_behavior": "Detects Fullstack architecture (has both storefront-next/ and cartridges/). Validates BOTH UI requirements (target-config.json exists, index.ts exists, locales en-US/en-GB/it-IT present) AND Backend requirements (cartridges/site_cartridges/ exists, package.json has hooks field, impex/install/ and impex/uninstall/ directories present, XML validates with xmllint, services use dotted notation, no hardcoded credentials). Reports architecture detection and validates all applicable rules."
+      "expected_behavior": "Detects Fullstack architecture (has both storefront-next/ and cartridges/). Validates BOTH UI requirements (target-config.json exists, index.ts exists, locales en-US/en-GB/it-IT present) AND Backend requirements (cartridges/site_cartridges/ exists, every cartridge root has a .project file, package.json has hooks field, impex/install/ and impex/uninstall/ directories present, XML validates with xmllint, services use dotted notation, no hardcoded credentials). Reports architecture detection and validates all applicable rules."
     },
     {
       "id": 5,

--- a/.github/ISSUE_TEMPLATE/app_update.yml
+++ b/.github/ISSUE_TEMPLATE/app_update.yml
@@ -92,7 +92,9 @@ body:
           required: true
         - label: I am NOT committing extracted directories (only new ZIP and updated manifest.json)
           required: true
-        - label: The ZIP contains no junk files (.DS_Store, __MACOSX, hidden files)
+        - label: The ZIP contains no junk hidden files (.DS_Store, __MACOSX, .env, secrets)
+          required: true
+        - label: Every cartridge root (cartridges/site_cartridges/*/, cartridges/bm_cartridges/*/) includes a .project file (may be empty)
           required: true
         - label: I have deleted the old ZIP version
           required: true

--- a/.github/ISSUE_TEMPLATE/new_app.yml
+++ b/.github/ISSUE_TEMPLATE/new_app.yml
@@ -129,7 +129,9 @@ body:
           required: true
         - label: I am NOT committing extracted directories (only ZIP, manifest.json, catalog.json)
           required: true
-        - label: The ZIP contains no junk files (.DS_Store, __MACOSX, hidden files)
+        - label: The ZIP contains no junk hidden files (.DS_Store, __MACOSX, .env, secrets)
+          required: true
+        - label: Every cartridge root (cartridges/site_cartridges/*/, cartridges/bm_cartridges/*/) includes a .project file (may be empty)
           required: true
         - label: Every entry in `tasksList.json` declares a unique non-empty `taskKey` (snake_case)
           required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,8 @@
 - [ ] SHA256 hash verified with: `shasum -a 256 [path-to-zip]`
 
 ### ZIP Content Validation
-- [ ] No junk files (`.DS_Store`, `__MACOSX`, `Thumbs.db`, hidden files)
+- [ ] No junk hidden files (`.DS_Store`, `__MACOSX`, `.env`, secrets)
+- [ ] Every cartridge root has a `.project` file (may be empty)
 - [ ] No registry path prefixes in ZIP (no `tax/`, `domain/`, etc.)
 - [ ] Required files present: `commerce-app.json`, `README.md`, `app-configuration/tasksList.json`
 - [ ] All referenced scripts/files exist

--- a/.github/scripts/test-validate-cartridge-project.sh
+++ b/.github/scripts/test-validate-cartridge-project.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATE="$SCRIPT_DIR/validate-cartridge-project.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT=""
+cleanup() { [[ -n "$TMPDIR_ROOT" ]] && rm -rf "$TMPDIR_ROOT"; }
+trap cleanup EXIT
+TMPDIR_ROOT="$(mktemp -d)"
+
+LAST_OUTPUT=""
+LAST_RC=0
+
+run_validate() {
+  local cap_root="$1"
+  LAST_RC=0
+  LAST_OUTPUT="$(bash "$VALIDATE" "$cap_root" 2>&1)" || LAST_RC=$?
+  LAST_RC=${LAST_RC:-0}
+}
+
+assert_passes() {
+  local desc="$1"; local cap_root="$2"
+  run_validate "$cap_root"
+  if [[ "$LAST_RC" -eq 0 ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 0, got $LAST_RC)"
+    echo "    output: $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_rejects() {
+  local desc="$1"; local cap_root="$2"; local expect_substr="$3"
+  run_validate "$cap_root"
+  if [[ "$LAST_RC" -ne 1 ]]; then
+    echo "  FAIL: $desc (expected exit 1, got $LAST_RC)"
+    echo "    output: $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$LAST_OUTPUT" != *"$expect_substr"* ]]; then
+    echo "  FAIL: $desc (output missing expected substring)"
+    echo "    expected substring: $expect_substr"
+    echo "    actual output:      $LAST_OUTPUT"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  echo "  PASS: $desc"
+  PASS=$((PASS + 1))
+}
+
+echo "=== cartridge .project validator tests ==="
+
+# --- Passing shapes ---------------------------------------------------
+
+case_dir="$TMPDIR_ROOT/no-cartridges"
+mkdir -p "$case_dir/storefront-next"
+assert_passes "no cartridges/ directory (UI-only app)" "$case_dir"
+
+case_dir="$TMPDIR_ROOT/empty-project-files"
+mkdir -p "$case_dir/cartridges/site_cartridges/int_vendor_app"
+mkdir -p "$case_dir/cartridges/bm_cartridges/bm_app"
+touch "$case_dir/cartridges/site_cartridges/int_vendor_app/.project"
+touch "$case_dir/cartridges/bm_cartridges/bm_app/.project"
+assert_passes "empty .project files in both cartridge roots" "$case_dir"
+
+case_dir="$TMPDIR_ROOT/nonempty-project-file"
+mkdir -p "$case_dir/cartridges/site_cartridges/int_vendor_app"
+cat > "$case_dir/cartridges/site_cartridges/int_vendor_app/.project" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+  <name>int_vendor_app</name>
+</projectDescription>
+EOF
+assert_passes "non-empty Eclipse .project file is left alone and passes" "$case_dir"
+
+case_dir="$TMPDIR_ROOT/only-site-cartridges"
+mkdir -p "$case_dir/cartridges/site_cartridges/int_vendor_app"
+touch "$case_dir/cartridges/site_cartridges/int_vendor_app/.project"
+assert_passes "backend-only app with only site_cartridges/" "$case_dir"
+
+# --- Rejecting shapes ---------------------------------------------------
+
+case_dir="$TMPDIR_ROOT/missing-site-project"
+mkdir -p "$case_dir/cartridges/site_cartridges/int_vendor_app"
+assert_rejects "missing .project in site_cartridges root" "$case_dir" \
+  "cartridges/site_cartridges/int_vendor_app/.project"
+
+case_dir="$TMPDIR_ROOT/missing-bm-project"
+mkdir -p "$case_dir/cartridges/site_cartridges/int_vendor_app"
+mkdir -p "$case_dir/cartridges/bm_cartridges/bm_app"
+touch "$case_dir/cartridges/site_cartridges/int_vendor_app/.project"
+assert_rejects "missing .project in bm_cartridges root" "$case_dir" \
+  "cartridges/bm_cartridges/bm_app/.project"
+
+case_dir="$TMPDIR_ROOT/missing-both"
+mkdir -p "$case_dir/cartridges/site_cartridges/int_vendor_app"
+mkdir -p "$case_dir/cartridges/bm_cartridges/bm_app"
+assert_rejects "missing .project in both cartridge roots" "$case_dir" \
+  "cartridges/site_cartridges/int_vendor_app/.project"
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.github/scripts/validate-cartridge-project.sh
+++ b/.github/scripts/validate-cartridge-project.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Validate that every cartridge root inside a CAP contains a .project file.
+#
+# Usage: validate-cartridge-project.sh <cap-root>
+#
+# Exit codes:
+#   0 - every cartridge root has a .project file (or the CAP has no
+#       cartridges/ directory at all — UI-only apps are skipped gracefully)
+#   1 - one or more cartridge roots are missing .project (errors on stderr)
+#   2 - usage error (bad args or unreadable input)
+#
+# Schema:
+#   - Cartridge roots are the immediate child directories of
+#     cartridges/site_cartridges/ and cartridges/bm_cartridges/ under the
+#     CAP root (whichever of the two groups exist).
+#   - Every cartridge root MUST contain a .project file. It may be empty
+#     (auto-created by scaffold/package tooling) or a real, non-empty
+#     Eclipse .project file — both PASS. b2c cartridge discovery requires
+#     this file to exist, regardless of contents.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $(basename "$0") <cap-root>" >&2
+  exit 2
+fi
+
+cap_root="$1"
+
+if [[ ! -d "$cap_root" ]]; then
+  echo "CAP root not found: $cap_root" >&2
+  exit 2
+fi
+
+cartridges_dir="$cap_root/cartridges"
+
+if [[ ! -d "$cartridges_dir" ]]; then
+  echo "No cartridges/ directory - OK (UI-only app)"
+  exit 0
+fi
+
+missing=()
+checked=0
+
+for group in site_cartridges bm_cartridges; do
+  group_dir="$cartridges_dir/$group"
+  [[ -d "$group_dir" ]] || continue
+
+  while IFS= read -r cartridge_dir; do
+    checked=$((checked + 1))
+    if [[ ! -f "$cartridge_dir/.project" ]]; then
+      missing+=("cartridges/$group/$(basename "$cartridge_dir")/.project")
+    fi
+  done < <(find "$group_dir" -mindepth 1 -maxdepth 1 -type d | sort)
+done
+
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "Missing required .project file(s) in cartridge root(s):" >&2
+  printf '  %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+echo "cartridges/ .project check passed ($checked cartridge root(s) checked)"
+exit 0

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -185,6 +185,17 @@ jobs:
               echo "  ✓ $admin_output"
             fi
 
+            # Every cartridge root must ship a .project file (required for
+            # b2c cartridge discovery). See .github/scripts/validate-cartridge-project.sh.
+            # Skips gracefully if the CAP has no cartridges/ directory (UI-only apps).
+            if ! project_output="$(bash ".github/scripts/validate-cartridge-project.sh" "$root" 2>&1)"; then
+              echo "::error file=$zip_path::cartridge .project validation failed:"
+              printf '%s\n' "$project_output"
+              rm -rf "$tmpdir"
+              exit 1
+            fi
+            echo "  ✓ $project_output"
+
             rm -rf "$tmpdir"
           done < changed_zips.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,6 @@ $RECYCLE.BIN/
 # Only commit ZIP files, manifest.json, and catalog.json
 **/commerce-*-app-v*/
 **/commerce-*-app-*/
+
+# build-it run logs (local only)
+docs/superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,3 @@ $RECYCLE.BIN/
 # Only commit ZIP files, manifest.json, and catalog.json
 **/commerce-*-app-v*/
 **/commerce-*-app-*/
-
-# build-it run logs (local only)
-docs/superpowers/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,13 +161,17 @@ Your response:
 
 ### 6. ZIP Contents
 - Single root folder: `commerce-{app-name}-app-v{version}/`
-- NO junk files: `.DS_Store`, `__MACOSX`, `Thumbs.db`, hidden files
+- NO junk hidden files: `.DS_Store`, `__MACOSX`, `Thumbs.db`, `.env`, secrets
 - NO `node_modules`, `.git`, IDE files
 - NO secret files (`.env`, `.key`, `.pem`, `.p12`, `.pfx`, `.jks`)
+- **REQUIRED:** Every cartridge root (each immediate child of `cartridges/site_cartridges/` and `cartridges/bm_cartridges/`) MUST include a `.project` file — may be empty, but must be present (required for b2c cartridge discovery)
 - Optional: `icons/` directory with ISV icon(s)
-- Use exclusions when creating ZIP:
+- Use exclusions when creating ZIP — do NOT use a blanket `-x "*/.*"`, it strips `.project`:
   ```bash
-  zip -r app.zip folder/ -x "*.DS_Store" -x "__MACOSX/*" -x "*/.*" -x "Thumbs.db"
+  zip -r app.zip folder/ \
+    -x "*.DS_Store" -x "*/*.DS_Store" -x "__MACOSX/*" -x "*/__MACOSX/*" \
+    -x "*/.git/*" -x "*/.env" -x "*/.env.*" -x "Thumbs.db" \
+    -x "*.key" -x "*.pem" -x "*.p12" -x "*.pfx" -x "*.jks"
   ```
 
 ### 7. Icons (Optional)
@@ -359,8 +363,14 @@ tax/avalara-tax/catalog.json
 # WRONG - Creates junk files
 zip -r app.zip folder/
 
-# RIGHT - Excludes junk files
+# WRONG - Blanket "*/.*" also strips the REQUIRED .project files from cartridges
 zip -r app.zip folder/ -x "*.DS_Store" -x "__MACOSX/*" -x "*/.*" -x "Thumbs.db"
+
+# RIGHT - Excludes junk explicitly, keeps .project
+zip -r app.zip folder/ \
+  -x "*.DS_Store" -x "*/*.DS_Store" -x "__MACOSX/*" -x "*/__MACOSX/*" \
+  -x "*/.git/*" -x "*/.env" -x "*/.env.*" -x "Thumbs.db" \
+  -x "*.key" -x "*.pem" -x "*.p12" -x "*.pfx" -x "*.jks"
 ```
 
 ## Understanding the Domain
@@ -468,7 +478,8 @@ Before suggesting `/submit-app-pr`, verify:
 
 **ZIP Contents:**
 - [ ] Single root folder: `commerce-{app-name}-app-v{version}/`
-- [ ] No junk files (`.DS_Store`, `__MACOSX`, hidden files)
+- [ ] No junk hidden files (`.DS_Store`, `__MACOSX`, `.env`, secrets)
+- [ ] Every cartridge root has a `.project` file (may be empty)
 - [ ] All required files present (commerce-app.json, README.md, etc.)
 
 **Manifest Validation:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ avalara-tax-v1.0.0.zip
 
 #### How to Generate the ZIP File
 
-When creating your ZIP file, it's important to exclude system files and hidden files that shouldn't be included in the archive. Use the following commands based on your operating system:
+When creating your ZIP file, it's important to exclude system files and other junk that shouldn't be included in the archive — but **every cartridge root MUST include a `.project` file** (see [Cartridge `.project` files](#cartridge-project-files) below), so don't reach for a blanket "exclude all hidden files" pattern. Use the following commands based on your operating system:
 
 ##### macOS & Linux (Terminal)
 
@@ -70,15 +70,21 @@ Both macOS and Linux use the `zip` utility. The `-x` flag is your best friend he
 
 **The Command:**
 ```bash
-zip -r my_archive.zip folder_to_zip/ -x "*.DS_Store" -x "__MACOSX/*" -x "*/.*" -x "Thumbs.db"
+zip -r my_archive.zip folder_to_zip/ \
+  -x "*.DS_Store" -x "*/*.DS_Store" -x "__MACOSX/*" -x "*/__MACOSX/*" \
+  -x "*/.git/*" -x "*/.env" -x "*/.env.*" -x "Thumbs.db" \
+  -x "*.key" -x "*.pem" -x "*.p12" -x "*.pfx" -x "*.jks"
 ```
 
 **Breakdown of the flags:**
 - `-r`: Stands for "recursive." It tells the computer to look inside every subfolder.
-- `"*.DS_Store"`: Excludes the macOS folder settings file.
-- `"__MACOSX/*"`: Prevents the creation of those annoying resource fork folders.
-- `"*/.*"`: The "nuclear option"—this excludes all hidden files (anything starting with a dot).
+- `"*.DS_Store"` / `"*/*.DS_Store"`: Excludes the macOS folder settings file.
+- `"__MACOSX/*"` / `"*/__MACOSX/*"`: Prevents the creation of those annoying resource fork folders.
+- `"*/.git/*"`, `"*/.env"`, `"*/.env.*"`: Excludes VCS metadata and env/secret files.
 - `"Thumbs.db"`: Excludes the Windows thumbnail cache.
+- `"*.key"`, `"*.pem"`, `"*.p12"`, `"*.pfx"`, `"*.jks"`: Excludes common secret/keystore file types.
+
+**Do NOT use `-x "*/.*"`** (the old "nuclear option" that excludes every dotfile) — it also strips the `.project` files that every cartridge root is required to ship.
 
 ##### Windows (PowerShell)
 
@@ -89,15 +95,21 @@ Windows doesn't have a native "exclude" flag built into its basic `Compress-Arch
 Get-ChildItem -Path ".\folder_name" -Recurse -File | Where-Object { 
     $_.FullName -notmatch '\\\.DS_Store$' -and 
     $_.FullName -notmatch '__MACOSX' -and 
-    $_.Name -notmatch '^\.' -and
-    $_.Name -notmatch 'Thumbs\.db'
+    $_.FullName -notmatch '\\\.git\\' -and
+    $_.Name -notmatch '^\.env' -and
+    $_.Name -notmatch 'Thumbs\.db' -and
+    $_.Name -notmatch '\.(key|pem|p12|pfx|jks)$'
 } | Compress-Archive -DestinationPath "my_archive.zip"
 ```
 
 **How this works:**
 - `Get-ChildItem`: Grabs every file in your folder.
-- `Where-Object`: This acts as a filter. We tell it to only keep files that do not match our "junk" patterns (no .DS_Store, no __MACOSX, no files starting with a dot, and no Thumbs.db).
+- `Where-Object`: This acts as a filter. We tell it to only keep files that do not match our "junk" patterns (no .DS_Store, no __MACOSX, no .git metadata, no .env/secret files, and no Thumbs.db). Note this deliberately does NOT filter out `.project` — every cartridge root must ship one.
 - `Compress-Archive`: Takes that filtered list and zips it up.
+
+##### Cartridge `.project` files
+
+Every cartridge root — each immediate child directory of `cartridges/site_cartridges/` and `cartridges/bm_cartridges/` — MUST contain a `.project` file. This is required for b2c cartridge discovery. An empty file is fine (the `/scaffold-app` and `/package-app` skills create these automatically); if you're importing an existing Eclipse-generated cartridge with a real (non-empty) `.project` file, leave it as-is. `/validate-app` and CI (`verify-zip.yml`) both fail the build if a cartridge root is missing this file.
 
 #### Delete Old ZIP Versions
 
@@ -619,7 +631,8 @@ Before submitting your PR, please verify:
 - [ ] SHA256 hash verified with: `shasum -a 256 [path-to-zip]`
 
 ### ZIP Content Validation
-- [ ] No junk files (`.DS_Store`, `__MACOSX`, `Thumbs.db`, hidden files)
+- [ ] No junk hidden files (`.DS_Store`, `__MACOSX`, `.env`, secrets)
+- [ ] Every cartridge root (`cartridges/site_cartridges/*/`, `cartridges/bm_cartridges/*/`) has a `.project` file (empty is fine — see [Cartridge `.project` files](#cartridge-project-files))
 - [ ] No registry path prefixes in ZIP (no `tax/`, `domain/`, etc.)
 - [ ] All required files present (commerce-app.json, README.md, tasksList.json, services.xml)
 - [ ] All referenced scripts/files exist
@@ -675,13 +688,25 @@ shasum -a 256 [domain]/[appName]/[appName]-v[version].zip
 ```
 
 ### Junk Files in ZIP
-**Problem:** CI detects `.DS_Store`, `__MACOSX`, or hidden files.
+**Problem:** CI detects `.DS_Store`, `__MACOSX`, `.env`, or other junk files.
 
-**Solution:** Recreate the ZIP with proper exclusions:
+**Solution:** Recreate the ZIP with proper exclusions. Do NOT use a blanket `-x "*/.*"` — it also strips the `.project` files every cartridge root is required to ship:
 ```bash
 zip -r [appName]-v[version].zip commerce-[appName]-app-v[version]/ \
-  -x "*.DS_Store" -x "__MACOSX/*" -x "*/.*" -x "Thumbs.db"
+  -x "*.DS_Store" -x "*/*.DS_Store" -x "__MACOSX/*" -x "*/__MACOSX/*" \
+  -x "*/.git/*" -x "*/.env" -x "*/.env.*" -x "Thumbs.db" \
+  -x "*.key" -x "*.pem" -x "*.p12" -x "*.pfx" -x "*.jks"
 ```
+
+### Missing `.project` File in Cartridge
+**Problem:** CI reports a cartridge root is missing a required `.project` file.
+
+**Solution:** Create an empty `.project` file in the cartridge root (don't overwrite one that already exists):
+```bash
+touch cartridges/site_cartridges/<cartridgeName>/.project
+touch cartridges/bm_cartridges/bm_<appName>/.project
+```
+Then regenerate the ZIP — see [Cartridge `.project` files](#cartridge-project-files).
 
 ### Version Mismatch
 **Problem:** `commerce-app.json` version doesn't match `manifest.json`.


### PR DESCRIPTION
## Summary
- Require every CAP cartridge root to ship a `.project` file (empty OK; existing Eclipse XML left alone)
- Scaffold/package skills auto-create missing `.project`; validate skill + `verify-zip` CI fail if missing
- Stop using blanket `-x "*/.*"` zip exclusions so `.project` is not stripped

## Test plan
- [x] Run `.github/scripts/test-validate-cartridge-project.sh`
- [x] Scaffold a backend app and confirm `.project` exists under site/BM cartridge roots
- [x] Package a CAP and confirm `unzip -l` lists `.../.project`
- [x] Confirm a CAP missing `.project` fails validate-app / verify-zip

@W-23748575