### PR TITLE
@W-23849761 | Validate translation locale filenames in 26.9

### DIFF
--- a/.github/scripts/test-validate-registry-translations.sh
+++ b/.github/scripts/test-validate-registry-translations.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VALIDATE="$SCRIPT_DIR/validate-registry-translations.sh"
+
+PASS=0
+FAIL=0
+TMPDIR_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_ROOT"' EXIT
+
+assert_passes() {
+  local desc="$1"
+  shift
+  local translations_dir
+  translations_dir="$(mktemp -d "$TMPDIR_ROOT/translations.XXXXXX")"
+  for locale in "$@"; do
+    printf '{}\n' > "$translations_dir/$locale.json"
+  done
+
+  local output
+  if output="$(bash "$VALIDATE" "$translations_dir" 2>&1)"; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "    output: $output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_rejects() {
+  local desc="$1"
+  local expect_substr="$2"
+  shift 2
+  local translations_dir
+  translations_dir="$(mktemp -d "$TMPDIR_ROOT/translations.XXXXXX")"
+  for locale in "$@"; do
+    printf '{}\n' > "$translations_dir/$locale.json"
+  done
+
+  local output rc=0
+  output="$(bash "$VALIDATE" "$translations_dir" 2>&1)" || rc=$?
+  if [[ "$rc" -eq 1 && "$output" == *"$expect_substr"* ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc (expected exit 1 containing '$expect_substr', got exit $rc)"
+    echo "    output: $output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== registry translations validator tests ==="
+
+assert_passes "empty directory is valid"
+assert_passes "all supported locale filenames are valid" \
+  ar-MA de en-US es fr it ja ko nl pl pt zh-CN zh-TW
+assert_rejects "underscore region separator is rejected" \
+  "use BCP-47 dash form" en-US zh_CN
+assert_rejects "unknown locale is rejected" \
+  "Unsupported registry translation locale file(s): xx-YY" en-US xx-YY
+
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]]

--- a/.github/scripts/test-validate-translations.sh
+++ b/.github/scripts/test-validate-translations.sh
@@ -113,10 +113,6 @@ assert_passes "en-US + matching de" \
   "tasks:en-US.json:$EN_BASIC" \
   "tasks:de.json:$DE_BASIC"
 
-assert_passes "app config locale filenames are not dash-case validated" \
-  "tasks:en-US.json:$EN_BASIC" \
-  "tasks:zh_CN.json:$EN_BASIC"
-
 assert_passes "tasksList taskKey present in en-US" \
   "tasks:en-US.json:$EN_BASIC" \
   "tasksList:$TASKS_LIST_OK"
@@ -143,6 +139,11 @@ assert_rejects "missing tasks key is rejected" \
 assert_rejects "empty name in en-US is rejected" \
   "missing/invalid name or description" \
   'tasks:en-US.json:{"tasks":{"setup_account":{"name":"","description":"d"}}}'
+
+assert_rejects "unsupported locale filename is rejected" \
+  "Unsupported locale file" \
+  "tasks:en-US.json:$EN_BASIC" \
+  "tasks:xx-YY.json:$EN_BASIC"
 
 assert_rejects "tasksList taskKey missing from en-US is rejected" \
   "not present in translations/en-US.json" \

--- a/.github/scripts/test-validate-translations.sh
+++ b/.github/scripts/test-validate-translations.sh
@@ -113,6 +113,10 @@ assert_passes "en-US + matching de" \
   "tasks:en-US.json:$EN_BASIC" \
   "tasks:de.json:$DE_BASIC"
 
+assert_passes "app config locale filenames are not dash-case validated" \
+  "tasks:en-US.json:$EN_BASIC" \
+  "tasks:zh_CN.json:$EN_BASIC"
+
 assert_passes "tasksList taskKey present in en-US" \
   "tasks:en-US.json:$EN_BASIC" \
   "tasksList:$TASKS_LIST_OK"
@@ -139,11 +143,6 @@ assert_rejects "missing tasks key is rejected" \
 assert_rejects "empty name in en-US is rejected" \
   "missing/invalid name or description" \
   'tasks:en-US.json:{"tasks":{"setup_account":{"name":"","description":"d"}}}'
-
-assert_rejects "unsupported locale filename is rejected" \
-  "Unsupported locale file" \
-  "tasks:en-US.json:$EN_BASIC" \
-  "tasks:xx-YY.json:$EN_BASIC"
 
 assert_rejects "tasksList taskKey missing from en-US is rejected" \
   "not present in translations/en-US.json" \

--- a/.github/scripts/test-validate-translations.sh
+++ b/.github/scripts/test-validate-translations.sh
@@ -145,6 +145,11 @@ assert_rejects "unsupported locale filename is rejected" \
   "tasks:en-US.json:$EN_BASIC" \
   "tasks:xx-YY.json:$EN_BASIC"
 
+assert_rejects "underscore locale filename is rejected" \
+  "Unsupported locale file" \
+  "tasks:en-US.json:$EN_BASIC" \
+  "tasks:zh_CN.json:$EN_BASIC"
+
 assert_rejects "tasksList taskKey missing from en-US is rejected" \
   "not present in translations/en-US.json" \
   "tasks:en-US.json:$EN_BASIC" \

--- a/.github/scripts/validate-registry-translations.sh
+++ b/.github/scripts/validate-registry-translations.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Validate locale filenames in commerce-apps-manifest/translations/.
+#
+# Usage: validate-registry-translations.sh <translations-dir>
+#
+# Exit codes:
+#   0 - locale filenames are valid
+#   1 - one or more locale filenames are unsupported
+#   2 - usage error (bad args or missing directory)
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $(basename "$0") <translations-dir>" >&2
+  exit 2
+fi
+
+translations_dir="$1"
+
+if [[ ! -d "$translations_dir" ]]; then
+  echo "Registry translations directory not found: $translations_dir" >&2
+  exit 2
+fi
+
+# Set of supported manifest locales. Region separators use BCP-47 dash form.
+SUPPORTED_LOCALES=("ar-MA" "de" "en-US" "es" "fr" "it" "ja" "ko" "nl" "pl" "pt" "zh-CN" "zh-TW")
+
+unsupported_locales=()
+while IFS= read -r locale_file; do
+  locale="$(basename "$locale_file" .json)"
+  supported_locale=false
+  for supported in "${SUPPORTED_LOCALES[@]}"; do
+    if [[ "$locale" == "$supported" ]]; then
+      supported_locale=true
+      break
+    fi
+  done
+  [[ "$supported_locale" == "false" ]] && unsupported_locales+=("$locale")
+done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json' | sort)
+
+if [[ ${#unsupported_locales[@]} -gt 0 ]]; then
+  echo "Unsupported registry translation locale file(s): ${unsupported_locales[*]} (supported: ${SUPPORTED_LOCALES[*]}; use BCP-47 dash form for region separators)" >&2
+  exit 1
+fi
+
+locale_count="$(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json' | wc -l | tr -d ' ')"
+echo "Registry translation locale filenames are valid ($locale_count file(s))"

--- a/.github/scripts/validate-translations.sh
+++ b/.github/scripts/validate-translations.sh
@@ -9,6 +9,8 @@
 #   2 - usage error (bad args or unreadable input)
 #
 # Schema:
+#   - Locale filenames must be in the supported set (kept in sync with the
+#     "Supported locales" table in CONTRIBUTING.md).
 #   - en-US.json is required when the directory exists.
 #   - Each locale file must be a JSON object with a "tasks" object whose
 #     entries each have non-empty "name" and "description" strings.
@@ -33,6 +35,10 @@ if [[ ! -d "$cap_root" ]]; then
   echo "CAP root not found: $cap_root" >&2
   exit 2
 fi
+
+# Set of supported BM locales — must match the table in CONTRIBUTING.md
+# under "Localizing app-shipped strings > Supported locales".
+SUPPORTED_LOCALES=("ar-MA" "de" "en-US" "es" "fr" "it" "ja" "ko" "nl" "pl" "pt" "zh-CN" "zh-TW")
 
 translations_dir="$cap_root/app-configuration/translations"
 
@@ -108,6 +114,22 @@ done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json'
 
 if [[ -n "$shape_errors" ]]; then
   echo "app-configuration/translations/ shape validation failed:$shape_errors" >&2
+  exit 1
+fi
+
+# Locale filenames must be in the supported set.
+unsupported_locales=()
+while IFS= read -r locale_file; do
+  fname="$(basename "$locale_file" .json)"
+  ok=false
+  for supported in "${SUPPORTED_LOCALES[@]}"; do
+    [[ "$fname" == "$supported" ]] && ok=true && break
+  done
+  [[ "$ok" == "false" ]] && unsupported_locales+=("$fname")
+done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
+
+if [[ ${#unsupported_locales[@]} -gt 0 ]]; then
+  echo "Unsupported locale file(s) in app-configuration/translations/: ${unsupported_locales[*]} (supported: ${SUPPORTED_LOCALES[*]})" >&2
   exit 1
 fi
 

--- a/.github/scripts/validate-translations.sh
+++ b/.github/scripts/validate-translations.sh
@@ -9,8 +9,6 @@
 #   2 - usage error (bad args or unreadable input)
 #
 # Schema:
-#   - Locale filenames must be in the supported set (kept in sync with the
-#     "Supported locales" table in CONTRIBUTING.md).
 #   - en-US.json is required when the directory exists.
 #   - Each locale file must be a JSON object with a "tasks" object whose
 #     entries each have non-empty "name" and "description" strings.
@@ -35,10 +33,6 @@ if [[ ! -d "$cap_root" ]]; then
   echo "CAP root not found: $cap_root" >&2
   exit 2
 fi
-
-# Set of supported BM locales — must match the table in CONTRIBUTING.md
-# under "Localizing app-shipped strings > Supported locales".
-SUPPORTED_LOCALES=("ar-MA" "de" "en-US" "es" "fr" "it" "ja" "ko" "nl" "pl" "pt" "zh-CN" "zh-TW")
 
 translations_dir="$cap_root/app-configuration/translations"
 
@@ -114,22 +108,6 @@ done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json'
 
 if [[ -n "$shape_errors" ]]; then
   echo "app-configuration/translations/ shape validation failed:$shape_errors" >&2
-  exit 1
-fi
-
-# Locale filenames must be in the supported set.
-unsupported_locales=()
-while IFS= read -r locale_file; do
-  fname="$(basename "$locale_file" .json)"
-  ok=false
-  for supported in "${SUPPORTED_LOCALES[@]}"; do
-    [[ "$fname" == "$supported" ]] && ok=true && break
-  done
-  [[ "$ok" == "false" ]] && unsupported_locales+=("$fname")
-done < <(find "$translations_dir" -mindepth 1 -maxdepth 1 -type f -name '*.json')
-
-if [[ ${#unsupported_locales[@]} -gt 0 ]]; then
-  echo "Unsupported locale file(s) in app-configuration/translations/: ${unsupported_locales[*]} (supported: ${SUPPORTED_LOCALES[*]})" >&2
   exit 1
 fi
 

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, edited, ready_for_review]
     paths:
       - '**/*.zip'
+      - 'commerce-apps-manifest/translations/**'
 
 jobs:
   verify-zips:
@@ -569,3 +570,9 @@ jobs:
 
             rm -rf "$tmpdir"
           done < changed_zips.txt
+
+      - name: Step 10 - Validate registry translation locale filenames
+        shell: bash
+        run: |
+          bash ".github/scripts/validate-registry-translations.sh" \
+            "commerce-apps-manifest/translations"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -513,9 +513,9 @@ Locale filenames are validated against the set of locales supported by Business 
 | Chinese (Simplified) | `zh-CN.json` |
 | Chinese (Traditional) | `zh-TW.json` |
 
-CI enforces this filename set for registry-level files under
-`commerce-apps-manifest/translations/`. Locale filenames packaged under
-`app-configuration/translations/` are not validated for dash case by the registry.
+CI enforces this filename set for both registry-level files under
+`commerce-apps-manifest/translations/` and locale files packaged under
+`app-configuration/translations/`.
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -513,7 +513,9 @@ Locale filenames are validated against the set of locales supported by Business 
 | Chinese (Simplified) | `zh-CN.json` |
 | Chinese (Traditional) | `zh-TW.json` |
 
-CI will reject locale files whose filenames are outside this set.
+CI enforces this filename set for registry-level files under
+`commerce-apps-manifest/translations/`. Locale filenames packaged under
+`app-configuration/translations/` are not validated for dash case by the registry.
 
 ---
 


### PR DESCRIPTION
## Summary
- validate registry translation filenames against the supported BCP-47 dash-form locales
- run the workflow when only `commerce-apps-manifest/translations/**` changes
- retain ZIP `app-configuration/translations/` dash-form validation and explicitly test that underscore filenames such as `zh_CN.json` are rejected

## Test plan
- [x] `bash .github/scripts/run-all-tests.sh`
- [x] `bash .github/scripts/test-validate-translations.sh`
- [x] `bash .github/scripts/validate-registry-translations.sh commerce-apps-manifest/translations`
- [x] Parse `.github/workflows/verify-zip.yml` with Ruby YAML