### PR TITLE
@W-23849761 | Wire registry locale validation into 26.9 CI

### DIFF
--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize]
     paths:
       - '.github/scripts/**'
+      - '.github/config/**'
 
 jobs:
   test-scripts:

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -5,6 +5,8 @@ on:
     types: [opened, reopened, synchronize, edited, ready_for_review]
     paths:
       - '**/*.zip'
+      - 'commerce-apps-manifest/translations/**'
+      - '.github/config/**'
 
 jobs:
   verify-zips:
@@ -569,3 +571,9 @@ jobs:
 
             rm -rf "$tmpdir"
           done < changed_zips.txt
+
+      - name: Step 10 - Validate registry translation locale files
+        shell: bash
+        run: |
+          bash ".github/scripts/validate-registry-translations.sh" \
+            "commerce-apps-manifest/translations"


### PR DESCRIPTION
## Summary
The forward-integration bot promoted the locale-validation **scripts** and `.github/config/required-bm-locales.txt` to `release/26.9` (via #119), but `GITHUB_TOKEN` cannot push `.github/workflows/**`. As a result 26.9 ended up with the validator scripts present but **nothing in CI invoking them** — effectively dead code. This PR restores the workflow wiring so 26.9 matches `release/26.8`.

- `verify-zip.yml`: add **Step 10 – Validate registry translation locale files** (runs `validate-registry-translations.sh`) and add `commerce-apps-manifest/translations/**` + `.github/config/**` path triggers
- `test-scripts.yml`: add `.github/config/**` path trigger

Scripts and `required-bm-locales.txt` are already on 26.9 from #119 and are **not** re-added here (avoids the conflicts that closed #116).

## Test plan
- [x] `bash .github/scripts/run-all-tests.sh` — 10 suites, 0 failed
- [x] Ruby YAML parse of `verify-zip.yml` and `test-scripts.yml`
- [x] Diff confirms both workflows now match `release/26.8` (modulo a pre-existing trailing-newline divergence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)