### PR TITLE
@W-23895509: Add job-level timeout to CI workflows

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   security:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/test-scripts.yml
+++ b/.github/workflows/test-scripts.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   test-scripts:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/verify-zip.yml
+++ b/.github/workflows/verify-zip.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   verify-zips:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
## What

Adds `timeout-minutes: 10` to the three CI jobs:

- `test-scripts` (`test-scripts.yml`)
- `security` (`security.yml`)
- `verify-zips` (`verify-zip.yml`)

## Why

On PR #123, a `test-scripts` run hung ~38 minutes on the `apt-get` "Install XML tools" step because the ubuntu-latest runner was wedged — the identical step in the `security` job on the same commit finished in 90s, confirming it was a bad runner, not the code. Without a cap, a wedged runner runs up to GitHub's 6h default before failing.

A job-level timeout is the minimal backstop: it caps the whole job (all steps, current and future) so a hung runner fails fast and is retriable, with no per-step maintenance. 10 min is generous over the normal ~2 min runtime, so it only fires on a genuine hang.

This is the `release/26.9` counterpart of the same change targeting `release/26.8` (#127).

🤖 Generated with [Claude Code](https://claude.com/claude-code)