### PR TITLE
@W-23331697 | Restore carousel manifest fields for 26.9

### DIFF
--- a/commerce-apps-manifest/manifest.json
+++ b/commerce-apps-manifest/manifest.json
@@ -28,9 +28,13 @@
       "domain": "tax",
       "type": "app",
       "provider": "thirdParty",
+      "companyName": "Avalara",
       "version": "1.0.1",
       "zip": "avalara-tax-v1.0.1.zip",
-      "sha256": "ff76d5c64f2c3779d1b3cc9af1500ce514d4c8c308b090bbe09fd942d84a615d"
+      "sha256": "ff76d5c64f2c3779d1b3cc9af1500ce514d4c8c308b090bbe09fd942d84a615d",
+      "badge": "popular",
+      "isFeatured": true,
+      "featuredLearnMoreUrl": "https://www.avalara.com/us/en/products/calculations.html"
     }
   ],
   "shipping": [
@@ -72,7 +76,12 @@
       "domain": "payment",
       "type": "app",
       "provider": "salesforce",
+      "badge": "new",
       "requiredFeatureToggle": "SalesforcePaymentsAllowed",
+      "isFeatured": true,
+      "featuredTagline": "Collect payments fast with a seamless end-to-end solution for Adyen, Stripe, and PayPal.",
+      "featuredLearnMoreUrl": "https://help.salesforce.com/s/articleView?id=cc.b2c_salesforce_payments.htm",
+      "featuredImageName": "sf-payments-featured.png",
       "version": "1.0.1",
       "zip": "sf-payments-v1.0.1.zip",
       "sha256": "4074a4385da0493fce66c8aab87f86d14a6cf22a376c2668149df6ccdff1c2e4",
@@ -108,7 +117,11 @@
       "provider": "thirdParty",
       "version": "1.0.0",
       "zip": "noibu-v1.0.0.zip",
-      "sha256": "f8f4aef7e920e8921ccf9c55aca2f27f1885eaa21851a1b21c1e622ed6747852"
+      "sha256": "f8f4aef7e920e8921ccf9c55aca2f27f1885eaa21851a1b21c1e622ed6747852",
+      "companyName": "Noibu",
+      "badge": "popular",
+      "isFeatured": true,
+      "featuredLearnMoreUrl": "https://www.noibu.com/"
     }
   ],
   "merchandising": [


### PR DESCRIPTION
## Summary
- Restores workspace-carousel fields (`isFeatured`, `featuredTagline`, `featuredLearnMoreUrl`, `featuredImageName`, `badge`, `companyName`) on Avalara Tax, Salesforce Payments, and Noibu.
- These were originally added in `77d46f4` (#105) on `release/26.9`, then wiped by the 26.8 → 26.9 auto-promote in `3febb44` (#113). That promote replaced equal-version manifest entries wholesale, so target-only carousel metadata was dropped.
- Current 26.9 versions/hashes are unchanged (Avalara remains `1.0.1`). Translations and `sf-payments-featured.png` were already on this branch.

## Test plan
- [ ] Confirm `commerce-apps-manifest/manifest.json` on this PR has carousel fields for `avalara-tax`, `sf-payments`, and `noibu`
- [ ] Confirm versions and sha256 hashes still match the current 26.9 ZIPs
- [ ] After merge, a follow-up is needed so the next 26.8 → 26.9 promote cannot wipe these fields again (`merge_manifest_entry` currently replaces the whole entry when versions are equal or newer)